### PR TITLE
Add ncurses + libedit

### DIFF
--- a/.orchestra/config/components/caliban.yml
+++ b/.orchestra/config/components/caliban.yml
@@ -16,6 +16,7 @@ dependencies:
   - revng
   - revng-c
   - boost
+  - libedit
 use_asan: false
 #@ end
 

--- a/.orchestra/config/components/libedit.yml
+++ b/.orchestra/config/components/libedit.yml
@@ -1,0 +1,34 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+#@ load("/lib/create_component.lib.yml", "single_build_component")
+
+#@ source_url = "https://thrysoee.dk/editline/libedit-20191231-3.1.tar.gz"
+
+#@yaml/text-templated-strings
+---
+#@ def libedit_args():
+license: COPYING
+configure: |
+  mkdir -p "$BUILD_DIR"
+  extract.sh --into "$BUILD_DIR" (@= source_url @)
+  cd "$BUILD_DIR"
+  ./configure \
+    --disable-examples \
+    --disable-static \
+    --enable-shared \
+    --prefix="$ORCHESTRA_ROOT" \
+    CFLAGS="(@= data.values.use_old_glibc_cflags @)" \
+    LDFLAGS="(@= data.values.use_old_glibc_lflags @) (@= data.values.modern_linker_flags @) -Wl,-rpath,$RPATH_PLACEHOLDER/lib"
+build_system: make
+build_dependencies:
+  - gcc-host-toolchain
+  - glibc
+dependencies:
+  - ncurses
+#@ end
+
+#@overlay/match by=overlay.all, expects=1
+#@overlay/match-child-defaults missing_ok=True
+---
+components:
+  libedit: #@ single_build_component(**libedit_args())

--- a/.orchestra/config/components/libfort.yml
+++ b/.orchestra/config/components/libfort.yml
@@ -1,23 +1,15 @@
 #@ load("@ytt:overlay", "overlay")
-
 #@ load("/lib/cmake.lib.yml", "cmake_boost_configuration", "typical_cmake_builds")
 
 ---
 #@ def build_args():
-test: true
-extra_cmake_args: #@ cmake_boost_configuration
+source_url: "https://github.com/seleznevae/libfort/archive/v0.4.2.tar.gz"
 build_dependencies:
+  - gcc-host-toolchain
   - cmake
   - glibc
-  - host-cxx-toolchain
 dependencies:
   - host-libcxx
-  - llvm
-  - revng
-  - revng-c
-  - boost
-  - libedit
-  - libfort
 use_asan: false
 #@ end
 
@@ -25,9 +17,7 @@ use_asan: false
 #@overlay/match-child-defaults missing_ok=True
 ---
 components:
-  caliban:
-    repository: caliban
-    license: LICENSE.md
-    binary_archives: private
+  libfort:
     default_build: optimized
+    license: LICENSE
     builds: #@ typical_cmake_builds(**build_args())

--- a/.orchestra/config/components/ncurses.yml
+++ b/.orchestra/config/components/ncurses.yml
@@ -1,0 +1,64 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+#@ load("/lib/create_component.lib.yml", "single_build_component")
+
+#@ source_url = "https://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.2.tar.gz"
+
+#@yaml/text-templated-strings
+---
+#@ def ncurses_args():
+license: COPYING
+configure: |
+  mkdir -p "$BUILD_DIR"
+  extract.sh --into "$BUILD_DIR" (@= source_url @)
+  cd "$BUILD_DIR"
+  ./configure \
+    --disable-stripping \
+    --disable-term-driver \
+    --disable-termcap \
+    --disable-widec \
+    --enable-colorfgbg \
+    --enable-const \
+    --enable-echo \
+    --enable-hard-tabs \
+    --enable-leaks \
+    --enable-overwrite \
+    --enable-symlinks \
+    --enable-warnings \
+    --with-cxx \
+    --with-cxx-binding \
+    --with-cxx-shared \
+    --with-macros \
+    --with-manpage-format=normal \
+    --with-progs \
+    --with-rcs-ids \
+    --with-shared \
+    --with-termlib \
+    --without-ada \
+    --without-assertions \
+    --without-debug \
+    --without-dlsym \
+    --without-expanded \
+    --without-gpm \
+    --without-hashed-db \
+    --without-profile \
+    --without-progs \
+    --without-pthread \
+    --without-reentrant \
+    --without-tack \
+    --without-tests \
+    --without-trace \
+    --prefix="$ORCHESTRA_ROOT" \
+    CFLAGS="(@= data.values.use_old_glibc_cflags @)" \
+    LDFLAGS="(@= data.values.use_old_glibc_lflags @) (@= data.values.modern_linker_flags @) -Wl,-rpath,$RPATH_PLACEHOLDER/lib"
+build_system: make
+build_dependencies:
+  - gcc-host-toolchain
+  - glibc
+#@ end
+
+#@overlay/match by=overlay.all, expects=1
+#@overlay/match-child-defaults missing_ok=True
+---
+components:
+  ncurses: #@ single_build_component(**ncurses_args())


### PR DESCRIPTION
This PR adds three new components now needed by caliban: 
* libedit
* ncurses
* libfort
and adds the corresponding dependencies in the caliban component.

(libedit and libfort are now needed by caliban-cli; ncurses is a dependency of libedit)