### PR TITLE
Add `cmake` variable with default cmake flags

### DIFF
--- a/.orchestra/config/components/llvm_common.lib.yml
+++ b/.orchestra/config/components/llvm_common.lib.yml
@@ -1,4 +1,6 @@
 #@ load("@ytt:data", "data")
+
+#@ load("/lib/cmake.lib.yml", "cmake")
 #@ load("/lib/fn_args.lib.yml", "mandatory")
 #@ load("/lib/shell.lib.yml", "expand_args")
 
@@ -8,7 +10,8 @@
 - |
   mkdir -p "$BUILD_DIR"
   cd "$BUILD_DIR";
-  cmake "(@= source_dir @)/llvm" \
+  (@= cmake @) \
+    "(@= source_dir @)/llvm" \
     -GNinja \
     -DCMAKE_BUILD_RPATH="\$ORIGIN/../lib:$ORCHESTRA_ROOT/lib" \
     -DCMAKE_INSTALL_RPATH="$RPATH_PLACEHOLDER/lib" \
@@ -17,7 +20,6 @@
     -DCMAKE_EXE_LINKER_FLAGS="(@= data.values.use_old_glibc_ldflags @) (@= cflags @) (@= data.values.modern_linker_flags @)" \
     -DCMAKE_SHARED_LINKER_FLAGS="(@= data.values.use_old_glibc_ldflags @) (@= cflags @) (@= data.values.modern_linker_flags @)" \
     -DCMAKE_MODULE_LINKER_FLAGS="(@= data.values.use_old_glibc_ldflags @) (@= cflags @) (@= data.values.modern_linker_flags @)" \
-    -DCMAKE_INSTALL_PREFIX="$ORCHESTRA_ROOT" \
     -DCMAKE_CXX_FLAGS="(@= data.values.use_old_glibc_cflags @) (@= cflags @)" \
     -DLLVM_TARGETS_TO_BUILD="X86;AMDGPU" \
     -DLLVM_ENABLE_DUMP=ON \

--- a/.orchestra/config/components/macos/libtapi.lib.yml
+++ b/.orchestra/config/components/macos/libtapi.lib.yml
@@ -1,4 +1,5 @@
 #@ load("/lib/make.lib.yml", "make")
+#@ load("/lib/cmake.lib.yml", "cmake")
 #@ load("/lib/cmake.lib.yml", "cmdline_cmake_base_configuration")
 #@ load("/lib/shell.lib.yml", "expand_args")
 
@@ -20,7 +21,8 @@ builds:
 
       sed -i 's|NOT APPLE|FALSE|' src/projects/libtapi/CMakeLists.txt
       sed -i 's|^|#include <limits>\n|' src/projects/libtapi/include/tapi/Core/ArchitectureSupport.h
-      cmake src/ \
+      (@= cmake @) \
+        src/ \
         (@= expand_args(cmdline_cmake_base_configuration(cmake_build_type="Release")) @) \
         -DLLVM_INCLUDE_TESTS=OFF
     install: |

--- a/.orchestra/config/components/revng_qa.yml
+++ b/.orchestra/config/components/revng_qa.yml
@@ -1,4 +1,6 @@
 #@ load("@ytt:overlay", "overlay")
+
+#@ load("/lib/cmake.lib.yml", "cmake")
 #@ load("/lib/create_component.lib.yml", "single_build_component")
 
 #@yaml/text-templated-strings
@@ -9,8 +11,8 @@ license: LICENSE
 configure: |
   mkdir -p "$BUILD_DIR"
   cd "$BUILD_DIR"; \
-  cmake "$SOURCE_DIR" \
-    -DCMAKE_INSTALL_PREFIX="$ORCHESTRA_ROOT" \
+  (@= cmake @) \
+    "$SOURCE_DIR" \
     -DTRIPLE_x86_64="x86_64-gentoo-linux-musl" \
     -DTRIPLE_mips="mips-unknown-linux-musl" \
     -DTRIPLE_mipsel="mipsel-unknown-linux-musl" \

--- a/.orchestra/config/lib/cmake.lib.yml
+++ b/.orchestra/config/lib/cmake.lib.yml
@@ -6,6 +6,25 @@
 
 #@yaml/text-templated-strings
 ---
+#@ def cmake_default_cmdline_extra_flags(
+#@  ):
+- -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+- -DCMAKE_INSTALL_PREFIX="$ORCHESTRA_ROOT"
+#@ end
+
+#@yaml/text-templated-strings
+---
+#@ def _cmake(
+#@  ):
+- |
+  cmake \
+    (@= expand_args(cmake_default_cmdline_extra_flags()) @)
+#@ end
+
+#@ cmake = _cmake()[0].rstrip()
+
+#@yaml/text-templated-strings
+---
 #@ def cmdline_cmake_base_configuration(
 #@        cmake_build_type=mandatory,
 #@        extra_compiler_flags="",
@@ -19,11 +38,9 @@
 - -DCMAKE_EXE_LINKER_FLAGS="(@= data.values.regular_linker_flags @)"
 - -DCMAKE_MODULE_LINKER_FLAGS="(@= data.values.regular_linker_flags @)"
 - -DCMAKE_SHARED_LINKER_FLAGS="(@= data.values.regular_linker_flags @)"
-- -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 - -DCMAKE_BUILD_RPATH="$RPATH_PLACEHOLDER/lib:$RPATH_PLACEHOLDER/(@= data.values.sanitizers_libs_path @):$RPATH_PLACEHOLDER/lib/revng/analyses"
 - -DCMAKE_INSTALL_RPATH="$RPATH_PLACEHOLDER/lib:$RPATH_PLACEHOLDER/(@= data.values.sanitizers_libs_path @):$RPATH_PLACEHOLDER/lib/revng/analyses"
 - -DCMAKE_BUILD_TYPE="(@= cmake_build_type @)"
-- -DCMAKE_INSTALL_PREFIX="$ORCHESTRA_ROOT"
 #@ end
 
 #@yaml/text-templated-strings
@@ -43,7 +60,6 @@
   set(CMAKE_EXE_LINKER_FLAGS "(@= data.values.regular_linker_flags @) (@= data.values.use_old_glibc_ldflags @)")
   set(CMAKE_MODULE_LINKER_FLAGS "(@= data.values.regular_linker_flags @) (@= data.values.use_old_glibc_ldflags @)")
   set(CMAKE_SHARED_LINKER_FLAGS "(@= data.values.regular_linker_flags @) (@= data.values.use_old_glibc_ldflags @)")
-  set(CMAKE_EXPORT_COMPILE_COMMANDS=ON)
   set(CMAKE_BUILD_RPATH "$RPATH_PLACEHOLDER/lib:$RPATH_PLACEHOLDER/(@= data.values.sanitizers_libs_path @):$RPATH_PLACEHOLDER/lib/revng/analyses")
   set(CMAKE_INSTALL_RPATH "$RPATH_PLACEHOLDER/lib:$RPATH_PLACEHOLDER/(@= data.values.sanitizers_libs_path @):$RPATH_PLACEHOLDER/lib/revng/analyses")
   set(CMAKE_BUILD_TYPE "(@= cmake_build_type @)")
@@ -100,10 +116,10 @@
     eof
 
     cd "$BUILD_DIR";
-    cmake "$SOURCE_DIR" \
+    (@= cmake @) \
+      "$SOURCE_DIR" \
       -G"(@= build_system @)" \
       -DCMAKE_TOOLCHAIN_FILE="$BUILD_DIR/toolchain.cmake" \
-      -DCMAKE_INSTALL_PREFIX="$ORCHESTRA_ROOT" \
       (@= expand_args(extra_cmake_args) @)
 
     (@- if post_configure_script: @)


### PR DESCRIPTION
Before this commit, cmake was called directly from orchestra components.
This fact made difficult to provide a set of flags for cmake to be used by default by all cmake projects built with orchestra.

For our builds there are a set of cmake flags that we always want to pass. Currently these flags are two (`CMAKE_INSTALL_PREFIX` and `CMAKE_EXPORT_COMPILE_COMMANDS`), but we might want to add more in the future.

This commit defines a `cmake_default_cmdline_extra_flags` function and a `cmake` variable.
The `cmake_default_cmdline_extra_flags` is the function that wraps all the cmake default flags that we want to pass to all cmake projects.
The `cmake` variable is a wrapper that allows orchestra components to call cmake with all the default flags specified in `cmake_default_cmdline_extra_flags`.

This commit updates all the cmake-based components, so that they now call `(@= cmake @)` instead of cmake, getting the new default arguments as expected.

This also fixes an issue with cmake-based components not generating `compile_commands.json` files as we expected.