### PR TITLE
Build all architectures in llvm

### DIFF
--- a/.orchestra/config/components/llvm.yml
+++ b/.orchestra/config/components/llvm.yml
@@ -10,6 +10,7 @@
 #@ def cmake_opts():
 - -DBUILD_SHARED_LIBS=ON
 - -DLLVM_ENABLE_PROJECTS="clang"
+- -DLLVM_TARGETS_TO_BUILD="AArch64;AMDGPU;ARM;Mips;SystemZ;X86"
 - -DCMAKE_C_COMPILER="(@= data.values.regular_c_compiler @)"
 - -DCMAKE_CXX_COMPILER="(@= data.values.regular_cxx_compiler @)"
 #@ end


### PR DESCRIPTION
This PR builds LLVM for all architectures which used in rev.ng. Needed by the new disassembler.