### PR TITLE
Ignore JSON config cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ sources
 .orchestra/source_archives
 .orchestra/installed_components
 .orchestra/config_cache.yml
+.orchestra/config_cache.json
 .orchestra/remote_refs_cache.json
 .orchestra/config/user_*.yml
 .idea


### PR DESCRIPTION
Orchestra now also caches the generated config as JSON. This PR simply adds that file to `.gitignore`