### PR TITLE
Improve CI debuggability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ sources
 .orchestra/source_archives
 .orchestra/installed_components
 .orchestra/config_cache.yml
+.orchestra/config_cache.json
 .orchestra/remote_refs_cache.json
 .orchestra/config/user_*.yml
 .idea

--- a/.orchestra/ci/ci-hook/.gitignore
+++ b/.orchestra/ci/ci-hook/.gitignore
@@ -1,0 +1,4 @@
+environment
+config.json
+revng-ci.service
+venv

--- a/.orchestra/ci/ci-hook/README.md
+++ b/.orchestra/ci/ci-hook/README.md
@@ -1,0 +1,24 @@
+## Howto deploy
+
+* Copy the project directory somewhere (e.g. /opt/revng-ci)
+* Create a virtualenv with the required dependencies
+  ```
+  sudo apt-get install python3-pip
+  python3 -m venv venv
+  source ./venv/bin/activate
+  pip install -r requirements.txt
+  deactivate
+  ```
+  **Warning**: it is important to create the virtualenv after copying 
+  the project in its target directory. Virtualenvs are not relocatable.
+* Create `config.json` file from config.example.json template
+* Create `environment` file from `environment.example` template with secrets
+  **Warning**: remember to `chown root:root` and `chmod 600`
+* Create systemd service, replacing {{ application_root }} in `revng-ci.example.service`
+* Install and enable systemd service
+  ```
+  sudo cp revng-ci.service /etc/systemd/system/revng-ci.service
+  sudo cp revng-ci.socket /etc/systemd/system/revng-ci.socket
+  sudo systemctl enable revng-ci.socket
+  sudo systemctl start revng-ci.socket
+  ```

--- a/.orchestra/ci/ci-hook/app.py
+++ b/.orchestra/ci/ci-hook/app.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+
+from datetime import date, timedelta
+from textwrap import dedent
+
+import gitlab
+from flask import Flask, request
+
+
+app = Flask(__name__)
+config_file = os.environ.get("CONFIG_FILE_PATH", "config.json")
+
+
+def get_env_or_fail(var_name):
+    value = os.getenv(var_name)
+    if value is None:
+        raise Exception(f"Environment variable {var_name} is not set!")
+    return value
+
+
+GITLAB_SECRET = get_env_or_fail("GITLAB_SECRET")
+GITHUB_SECRET = get_env_or_fail("GITHUB_SECRET").encode("utf-8")
+revng_push_ci_private_key_b64 = get_env_or_fail("REVNG_PUSH_CI_PRIVATE_KEY_BASE64")
+revng_push_ci_private_key = base64.b64decode(revng_push_ci_private_key_b64).decode("utf-8")
+ADMIN_TOKEN = get_env_or_fail("GITLAB_ADMIN_TOKEN")
+
+try:
+    with open(config_file) as f:
+        config = json.load(f)
+except IOError:
+    print(f"Could not open configuration file ({config_file})")
+    exit(1)
+
+allowed_to_push = config["allowed_to_push"]
+GITLAB_URL = config["gitlab_url"]
+PROJECT_ID = config["project_id"]
+BRANCH = config["branch"]
+mapping = config["github_to_gitlab_mapping"]
+default_user = config["default_user"]
+ci_user = config["ci_user"]
+
+
+pusher_user_options = dedent("""
+    #@data/values
+    ---
+    #@overlay/match missing_ok=True
+    remote_base_urls:
+    - public: git@github.com:revng
+    - private: git@rev.ng:revng-private
+
+    #@overlay/match missing_ok=True
+    binary_archives:
+    - public: git@rev.ng:revng/binary-archives.git
+    - private: git@rev.ng:revng-private/binary-archives.git
+""")
+
+
+def hub_to_lab(username):
+    if username not in mapping:
+        return default_user
+    else:
+        return mapping[username]
+
+
+class ImpersonationToken:
+    def __init__(self, user):
+        self.user = user
+
+    def __enter__(self):
+        self.impersonation_token = self.user.impersonationtokens.create({
+            "name": "ci-temporary-token",
+            "scopes": ["api"],
+            "expires_at": (date.today() + timedelta(days=2)).strftime("%Y-%m-%d")
+        })
+        return self.impersonation_token.token
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        impersonation_token_id = self.impersonation_token.id
+        self.user.impersonationtokens.delete(impersonation_token_id)
+        assert not self.user.impersonationtokens.get(impersonation_token_id).active
+
+
+def trigger_ci(username, repo_url, ref, before, after):
+    # Ignore pushes by the CI itself
+    if username == ci_user:
+        return
+
+    admin_gl = gitlab.Gitlab(GITLAB_URL, private_token=ADMIN_TOKEN)
+    admin_gl.auth()
+
+    matching = admin_gl.users.list(username=username)
+    if len(matching) != 1:
+        raise Exception("Unexpected number of users matching " + username)
+    user_id = matching[0].id
+
+    user = admin_gl.users.get(user_id)
+    with ImpersonationToken(user) as token:
+        user_gl = gitlab.Gitlab(GITLAB_URL, private_token=token)
+        user_gl.auth()
+        project = user_gl.projects.get(PROJECT_ID)
+
+        variables = {
+            "TARGET_COMPONENTS_URL": repo_url,
+            "COMMIT_BEFORE": before,
+            "COMMIT_AFTER": after,
+            "PUSHED_REF": ref
+        }
+
+        if username in allowed_to_push:
+            variables["BASE_USER_OPTIONS_YML"] = pusher_user_options
+            variables["SSH_PRIVATE_KEY"] = revng_push_ci_private_key
+
+        parameters = {
+            "ref": BRANCH,
+            "variables": [{"key": key, "value": value}
+                          for key, value
+                          in variables.items()]
+        }
+        print(json.dumps(parameters, indent=2))
+        pipeline = project.pipelines.create(parameters)
+
+
+@app.route('/ci-hook/gitlab', methods=["POST"])
+def gitlab_hook():
+    headers = dict(request.headers)
+    if headers.get("X-Gitlab-Token", "") != GITLAB_SECRET:
+        return "Invalid token\n", 403
+
+    data = request.json
+    trigger_ci(data["user_username"],
+               data["project"]["git_http_url"] + " " + data["project"]["git_ssh_url"],
+               data["ref"],
+               data["before"],
+               data["after"])
+    return "All good\n"
+
+
+@app.route('/ci-hook/github', methods=["POST"])
+def github_hook():
+    headers = dict(request.headers)
+    signature = 'sha256=' + hmac.new(GITHUB_SECRET, request.data, hashlib.sha256).hexdigest()
+    if signature != headers.get("X-Hub-Signature-256"):
+        return "Invalid signature\n", 403
+
+    if headers.get("X-Github-Event", "") == "push":
+        data = request.json
+        trigger_ci(hub_to_lab(data["sender"]["login"]),
+                   data["repository"]["clone_url"],
+                   data["ref"],
+                   data["before"],
+                   data["after"])
+
+    return "All good\n"

--- a/.orchestra/ci/ci-hook/config.example.json
+++ b/.orchestra/ci/ci-hook/config.example.json
@@ -1,0 +1,11 @@
+{
+    "allowed_to_push": ["user1", "user2"],
+    "github_to_gitlab_mapping": {
+        "someone-github-username": "someone-gitlab-username"
+    },
+    "default_user": "anonymous-ci-user",
+    "ci_user": "push-ci-user",
+    "gitlab_url": "https://gitlab-url.com",
+    "project_id": 123,
+    "branch": "master"
+}

--- a/.orchestra/ci/ci-hook/environment.example
+++ b/.orchestra/ci/ci-hook/environment.example
@@ -1,0 +1,13 @@
+# Gitlab API token
+GITLAB_SECRET={GITLAB_SECRET}
+
+# Gitlab API token
+GITHUB_SECRET={GITHUB_SECRET}
+
+# Gitlab admin impersonation token
+GITLAB_ADMIN_TOKEN={GITLAB_ADMIN_TOKEN}
+
+# Private ssh key with push permissions.
+# Escapes such as \ to go to newline and \n to insert it in place are supported since systemd 239,
+# so for now we must encode the SSH private key with `base64 -w0`
+REVNG_PUSH_CI_PRIVATE_KEY_BASE64={REVNG_PUSH_CI_PRIVATE_KEY_BASE64}

--- a/.orchestra/ci/ci-hook/requirements.txt
+++ b/.orchestra/ci/ci-hook/requirements.txt
@@ -1,0 +1,3 @@
+gunicorn
+flask
+python-gitlab

--- a/.orchestra/ci/ci-hook/revng-ci.example.service
+++ b/.orchestra/ci/ci-hook/revng-ci.example.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=revng-ci
+Requires=revng-ci.socket
+After=network.target
+
+[Service]
+Type=notify
+DynamicUser=yes
+RuntimeDirectory=revng-ci
+WorkingDirectory={{ application_root }}
+ExecStart={{ application_root }}/venv/bin/gunicorn --workers 4 --bind unix:/run/revng-ci.sock wsgi:app
+EnvironmentFile={{ application_root }}/environment
+ExecReload=/bin/kill -s HUP $MAINPID
+KillMode=mixed
+TimeoutStopSec=5
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/.orchestra/ci/ci-hook/revng-ci.socket
+++ b/.orchestra/ci/ci-hook/revng-ci.socket
@@ -1,0 +1,14 @@
+[Unit]
+Description=revng-ci socket
+
+[Socket]
+ListenStream=/run/revng-ci.sock
+# Our service won't need permissions for the socket, since it
+# inherits the file descriptor by socket activation
+# only the nginx daemon will need access to the socket
+User=www-data
+# Optionally restrict the socket permissions even more.
+Mode=600
+
+[Install]
+WantedBy=sockets.target

--- a/.orchestra/ci/ci-hook/wsgi.py
+++ b/.orchestra/ci/ci-hook/wsgi.py
@@ -1,0 +1,4 @@
+from app import app
+
+if __name__ == "__main__":
+    app.run()

--- a/.orchestra/ci/ci.sh
+++ b/.orchestra/ci/ci.sh
@@ -156,77 +156,83 @@ for TARGET_COMPONENT in $TARGET_COMPONENTS; do
     fi
 done
 
-#
-# Promote `next-*` branches to `*`
-#
-if test "$RESULT" -eq 0; then
+if test "$PUSH_CHANGES" = 1; then
+    #
+    # Promote `next-*` branches to `*`
+    #
+    if test "$RESULT" -eq 0; then
 
-    # Clone all the components having branch next-*
-    for COMPONENT in $(orc components --branch 'next-*' | grep '^Component' | awk '{ print $2 }'); do
-        if ! test -d "sources/$COMPONENT"; then
-           orc clone "$COMPONENT"
-        fi
-    done
-
-    # Promote next-* to *
-    for SOURCE_PATH in $(orc ls --git-sources); do
-        if test -e "$SOURCE_PATH/.git"; then
-            cd "$SOURCE_PATH"
-            BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-            if test "${BRANCH:0:5}" == "next-"; then
-                PUSH_TO="${BRANCH:5}"
-                git branch -d "$PUSH_TO" || true
-                git checkout -b "$PUSH_TO" "$BRANCH"
-                git push origin "$PUSH_TO"
+        # Clone all the components having branch next-*
+        for COMPONENT in $(orc components --branch 'next-*' | grep '^Component' | awk '{ print $2 }'); do
+            if ! test -d "sources/$COMPONENT"; then
+                orc clone "$COMPONENT"
             fi
-            cd -
+        done
+
+        # Promote next-* to *
+        for SOURCE_PATH in $(orc ls --git-sources); do
+            if test -e "$SOURCE_PATH/.git"; then
+                cd "$SOURCE_PATH"
+                BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+                if test "${BRANCH:0:5}" == "next-"; then
+                    PUSH_TO="${BRANCH:5}"
+                    git branch -d "$PUSH_TO" || true
+                    git checkout -b "$PUSH_TO" "$BRANCH"
+                    git push origin "$PUSH_TO"
+                fi
+                cd -
+            fi
+        done
+
+        orc fix-binary-archives-symlinks
+    fi
+
+    #
+    # Push to binary archives
+    #
+    for BINARY_ARCHIVE_PATH in $(orc ls --binary-archives); do
+
+        cd "$BINARY_ARCHIVE_PATH"
+
+        # Ensure we have git lfs
+        git lfs >& /dev/null
+
+        git config user.email "$PUSH_BINARY_ARCHIVE_EMAIL"
+        git config user.name "$PUSH_BINARY_ARCHIVE_NAME"
+
+        if ! test -e .gitattributes; then
+            git lfs track "*.tar.gz"
+            git add .gitattributes
+            git commit -m'Initialize .gitattributes'
         fi
+
+        ls -lh
+        git add .
+
+        # TODO: cleanup-binary-archives.sh
+
+        if ! git diff --cached --quiet; then
+            git commit -m'Automatic binary archives'
+            git status
+            git stash
+            GIT_LFS_SKIP_SMUDGE=1 git fetch
+            GIT_LFS_SKIP_SMUDGE=1 git rebase -Xtheirs origin/master
+
+            git config --add lfs.dialtimeout 300
+            git config --add lfs.tlstimeout 300
+            git config --add lfs.activitytimeout 300
+            git config --add lfs.keepalive 300
+            git push
+            git lfs push origin master
+        else
+            log "Nothing new to push"
+        fi
+
     done
 
-    orc fix-binary-archives-symlinks
+    exit "$RESULT"
+
+else
+    echo "PUSH_CHANGES != 1, exiting without pushing changes"
+    exit $RESULT
 fi
-
-#
-# Push to binary archives
-#
-for BINARY_ARCHIVE_PATH in $(orc ls --binary-archives); do
-
-    cd "$BINARY_ARCHIVE_PATH"
-
-    # Ensure we have git lfs
-    git lfs >& /dev/null
-
-    git config user.email "$PUSH_BINARY_ARCHIVE_EMAIL"
-    git config user.name "$PUSH_BINARY_ARCHIVE_NAME"
-
-    if ! test -e .gitattributes; then
-        git lfs track "*.tar.gz"
-        git add .gitattributes
-        git commit -m'Initialize .gitattributes'
-    fi
-
-    ls -lh
-    git add .
-
-    # TODO: cleanup-binary-archives.sh
-
-    if ! git diff --cached --quiet; then
-        git commit -m'Automatic binary archives'
-        git status
-        git stash
-        GIT_LFS_SKIP_SMUDGE=1 git fetch
-        GIT_LFS_SKIP_SMUDGE=1 git rebase -Xtheirs origin/master
-
-        git config --add lfs.dialtimeout 300
-        git config --add lfs.tlstimeout 300
-        git config --add lfs.activitytimeout 300
-        git config --add lfs.keepalive 300
-        git push
-        git lfs push origin master
-    else
-        log "Nothing new to push"
-    fi
-
-done
-
-exit "$RESULT"

--- a/.orchestra/ci/ci.sh
+++ b/.orchestra/ci/ci.sh
@@ -134,8 +134,16 @@ find ..
 orc update --no-config
 
 # Print debugging information
-orc graph -b revng-distributable
+# Full dependency graph
+orc graph -b
+# Solved dependency graph for the target component
+orc graph --solved -b "$TARGET_COMPONENT"
+# Information about the components
 orc components --hashes --deps
+# Binary archives commit
+for BINARY_ARCHIVE_PATH in $(orc ls --binary-archives); do
+    echo "Commit for $BINARY_ARCHIVE_PATH:" "$(git -C "$BINARY_ARCHIVE_PATH" rev-parse HEAD)"
+done
 
 #
 # Actually run the build

--- a/.orchestra/ci/ci.sh
+++ b/.orchestra/ci/ci.sh
@@ -19,7 +19,7 @@ cd "$DIR"
 #
 set +x
 if test -n "$SSH_PRIVATE_KEY"; then
-    eval $(ssh-agent -s)
+    eval "$(ssh-agent -s)"
     echo "$SSH_PRIVATE_KEY" | tr -d '\r' | ssh-add -
     unset SSH_PRIVATE_KEY
     mkdir -p ~/.ssh
@@ -29,8 +29,8 @@ if test -n "$SSH_PRIVATE_KEY"; then
     if ! test -e ~/.ssh/config; then
         cat > ~/.ssh/config <<EOF
 Host *
-   StrictHostKeyChecking no
-   UserKnownHostsFile=/dev/null
+    StrictHostKeyChecking no
+    UserKnownHostsFile=/dev/null
 EOF
     fi
 fi
@@ -75,7 +75,7 @@ if test -e ../config/user_options.yml; then
 fi
 
 REMOTE="$(git remote get-url origin | sed 's|^\([^:]*:\)\([^/]\)|\1/\2|')"
-GITLAB_ROOT="$(dirname $(dirname $REMOTE))"
+GITLAB_ROOT="$(dirname "$(dirname "$REMOTE")")"
 echo "$BASE_USER_OPTIONS_YML" | sed "s|%GITLAB_ROOT%|$GITLAB_ROOT|g" > ../config/user_options.yml
 
 # Register target components


### PR DESCRIPTION
This PR modifies the CI script in the following ways:
* print the full graph of all the components known to orchestra (not limited to revng-distributable)
* print solved graph for the requested component (for debugging orchestra action scheduler)
* introduce a `$PUSH_CHANGES` environment variable; if not set to 1, the CI script will exit before pushing changes.
  Intended as a failsafe against involuntary pushing changes while debugging the CI.
* print the commit hashes of the binary archives in use

Also:
* adds to `.gitignore` the JSON file where orchestra caches its configuration