### PR TITLE
Unset environment variables affecting compilation/loading

### DIFF
--- a/.orchestra/config/components.yml
+++ b/.orchestra/config/components.yml
@@ -22,6 +22,12 @@ environment:
   - HARD_FLAGS_LINK: #@ str(datavalue("hard_flags_link"))
   - HARD_FLAGS_LINK_LATE: #@ str(datavalue("hard_flags_link_late"))
   - HARD_FLAGS_LINK_GOLD: #@ str(datavalue("hard_flags_link_gold"))
+  - "-LD_LIBRARY_PATH": ""
+  - "-COMPILER_PATH": ""
+  - "-CPATH": ""
+  - "-C_INCLUDE_PATH": ""
+  - "-CPLUS_INCLUDE_PATH": ""
+  - "-OBJC_INCLUDE_PATH": ""
 
 paths: #@ datavalue("paths", default={})
 remote_base_urls: #@ datavalue("remote_base_urls")


### PR DESCRIPTION
Unset the following environment variables

- LD_LIBRARY_PATH
- COMPILER_PATH
- CPATH
- C_INCLUDE_PATH
- CPLUS_INCLUDE_PATH
- OBJC_INCLUDE_PATH

This patch requires support from orchestra, still to be merged from this PR https://github.com/revng/revng-orchestra/pull/17