### PR TITLE
Add pip cache cleanup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains the orchestra configuration for rev.ng.
 
 * Install orchestra script
   ```sh
+  pip3 cache remove orchestra # pip fails to detect stale caches when downloading zips from github
   pip3 install --user --force-reinstall https://github.com/revng/revng-orchestra/archive/master.zip
   ```
 * Make sure `orc` is in PATH


### PR DESCRIPTION
`pip` sometimes fails to detect stale archives when downloading from github. To work around this issue this PR adds a command which purges orchestra archives from pip cache.