### PR TITLE
Fix errors detected by schema validation

### DIFF
--- a/.orchestra/config/components/llvm_documentation.yml
+++ b/.orchestra/config/components/llvm_documentation.yml
@@ -8,7 +8,7 @@ repository: llvm-project
 license: llvm/LICENSE.TXT
 builds:
   default:
-    depencencies:
+    dependencies:
       - llvm
     configure: |
       rm -rf "$BUILD_DIR"

--- a/.orchestra/config/components/llvmcpy.yml
+++ b/.orchestra/config/components/llvmcpy.yml
@@ -5,7 +5,7 @@ repository: llvmcpy
 license: LICENSE.txt
 builds:
   default:
-    depencencies:
+    dependencies:
       - llvm
     configure: |
       mkdir -p "$BUILD_DIR"

--- a/.orchestra/config/components/toolchain/lib/musl.lib.yml
+++ b/.orchestra/config/components/toolchain/lib/musl.lib.yml
@@ -43,9 +43,6 @@ build_dependencies:
 #! and we want take it into account without checking explicitly for specific musl
 
 #@   source_url = "http://www.musl-libc.org/releases/musl-" + musl_version + ".tar.gz"
-build: |
-  cd "$BUILD_DIR"
-  (@= make @) include/bits/alltypes.h || (@= make @) obj/include/bits/alltypes.h
 install: |
   cd "$BUILD_DIR"
   (@= make @) include/bits/alltypes.h || (@= make @) obj/include/bits/alltypes.h


### PR DESCRIPTION
This PR fixes:
- a typo in llvmcpy (`s/depencencies/dependencies`)
- a typo in llvm-documentation (`s/depencencies/dependencies`)
- a leftover `build` property in musl from orchestra early days
