### PR TITLE
Fix: CI - switch orchestra remote to ssh

### DIFF
--- a/.orchestra/ci/ci-hook/app.py
+++ b/.orchestra/ci/ci-hook/app.py
@@ -45,6 +45,9 @@ mapping = config["github_to_gitlab_mapping"]
 default_user = config["default_user"]
 ci_user = config["ci_user"]
 
+ORCHESTRA_CONFIG_REPO_HTTP_URL = config["orchestra_config_repo_http_url"]
+ORCHESTRA_CONFIG_REPO_SSH_URL = config["orchestra_config_repo_ssh_url"]
+
 
 pusher_user_options = dedent("""
     #@data/values
@@ -109,12 +112,15 @@ def trigger_ci(username, repo_url, ref, before, after):
             "TARGET_COMPONENTS_URL": repo_url,
             "COMMIT_BEFORE": before,
             "COMMIT_AFTER": after,
-            "PUSHED_REF": ref
+            "PUSHED_REF": ref,
+            "ORCHESTRA_CONFIG_REPO_HTTP_URL": ORCHESTRA_CONFIG_REPO_HTTP_URL,
+            "ORCHESTRA_CONFIG_REPO_SSH_URL": ORCHESTRA_CONFIG_REPO_SSH_URL
         }
 
         if username in allowed_to_push:
             variables["BASE_USER_OPTIONS_YML"] = pusher_user_options
             variables["SSH_PRIVATE_KEY"] = revng_push_ci_private_key
+            variables["PUSH_CHANGES"] = 1
 
         parameters = {
             "ref": BRANCH,

--- a/.orchestra/ci/ci-hook/config.example.json
+++ b/.orchestra/ci/ci-hook/config.example.json
@@ -7,5 +7,7 @@
     "ci_user": "push-ci-user",
     "gitlab_url": "https://gitlab-url.com",
     "project_id": 123,
-    "branch": "master"
+    "branch": "master",
+    "orchestra_config_repo_http_url": "https://github.com/revng/orchestra",
+    "orchestra_config_repo_ssh_url": "git@github.com:revng/orchestra"
 }

--- a/.orchestra/ci/ci-run.sh
+++ b/.orchestra/ci/ci-run.sh
@@ -68,6 +68,11 @@ Host *
     UserKnownHostsFile=/dev/null
 EOF
     fi
+
+    # Change orchestra remote to ssh if we were given the URL
+    if [[ -n "$ORCHESTRA_CONFIG_REPO_SSH_URL" ]]; then
+        git -C "$ORCHESTRA_ROOT" remote set-url origin "$ORCHESTRA_CONFIG_REPO_SSH_URL"
+    fi
 fi
 set -x
 


### PR DESCRIPTION
Switches the orchestra configuration remote to ssh if a deploy key is available, to be able to promote next-* branches.