### PR TITLE
Schema updates required by orchestra testsuite branch

### DIFF
--- a/.orchestra/config/components/llvm.yml
+++ b/.orchestra/config/components/llvm.yml
@@ -26,7 +26,6 @@ builds:
     #@ cflags = f_options["extra_compiler_flags"]
     #@ ndebug = f_options["ndebug"]
     (@= flavor @):
-      test: true
       configure: #@ configure_llvm(cmake_build_type=build_type, cflags=cflags, additional_cmake_options=cmake_opts(), source_dir="$SOURCE_DIR")
       install: |
         cd "$BUILD_DIR"

--- a/.orchestra/config/components/toolchain/lib/binutils.lib.yml
+++ b/.orchestra/config/components/toolchain/lib/binutils.lib.yml
@@ -52,7 +52,8 @@ configure: |
     CFLAGS="-w -ggdb3 -O3" \
     CXXFLAGS="-w -ggdb3 -O3"
 build_system: make
-add_to_path: ${ORCHESTRA_ROOT}/x86_64-pc-linux-gnu/(@= triple @)/binutils-bin/(@= binutils_version @)
+add_to_path:
+  - ${ORCHESTRA_ROOT}/x86_64-pc-linux-gnu/(@= triple @)/binutils-bin/(@= binutils_version @)
 build_dependencies:
   - glibc
   - toolchain/host/gcc

--- a/.orchestra/config/components/toolchain/lib/gcc.lib.yml
+++ b/.orchestra/config/components/toolchain/lib/gcc.lib.yml
@@ -190,5 +190,6 @@ default_build: stage2
 builds:
   stage1: #@ gcc_build(stage=1, **kwargs)
   stage2: #@ gcc_build(stage=2, **kwargs)
-add_to_path: ${ORCHESTRA_ROOT}/x86_64-pc-linux-gnu/(@= kwargs["triple"] @)/gcc-bin/(@= kwargs["gcc_version"] @)
+add_to_path:
+  - ${ORCHESTRA_ROOT}/x86_64-pc-linux-gnu/(@= kwargs["triple"] @)/gcc-bin/(@= kwargs["gcc_version"] @)
 #@ end

--- a/.orchestra/config/components/toolchain/macos/sdk.yml
+++ b/.orchestra/config/components/toolchain/macos/sdk.yml
@@ -14,7 +14,8 @@ builds:
       # echo "TODO: macosx sdk" && exit 1
       # create-package.sh Xcode_9.xip
       extract.sh --into "${TMP_ROOT}${ORCHESTRA_ROOT}" "(@= sdk_archive_name @)"
-add_to_path: "$ORCHESTRA_DOTDIR/support/repackage-apple-sdk"
+add_to_path:
+  - $ORCHESTRA_DOTDIR/support/repackage-apple-sdk
 #@ end
 
 #@overlay/match by=overlay.all, expects=1

--- a/.orchestra/config/lib/cmake.lib.yml
+++ b/.orchestra/config/lib/cmake.lib.yml
@@ -112,9 +112,6 @@
 
   #@ if/end opts["ndebug"] == False:
   ndebug: false
-
-  #@ if/end test:
-  test: #@ test
 #@ end
 
 #@ end


### PR DESCRIPTION
This PR will be required to be merged after https://github.com/revng/revng-orchestra/pull/23, as some backwards-incompatible configuration schema changes were introduced. Summary:

- the `test` property of the builds is gone. Install scripts should run tests when `$RUN_TESTS == 1`, this did not change.
- the `add_to_path` property of the components is now a list of strings, for consistency with the global `add_to_path`
