### PR TITLE
CI fixes

### DIFF
--- a/.orchestra/ci/ci-hook/app.py
+++ b/.orchestra/ci/ci-hook/app.py
@@ -120,7 +120,7 @@ def trigger_ci(username, repo_url, ref, before, after):
         if username in allowed_to_push:
             variables["BASE_USER_OPTIONS_YML"] = pusher_user_options
             variables["SSH_PRIVATE_KEY"] = revng_push_ci_private_key
-            variables["PUSH_CHANGES"] = 1
+            variables["PUSH_CHANGES"] = "1"
 
         parameters = {
             "ref": BRANCH,

--- a/.orchestra/ci/ci-run.sh
+++ b/.orchestra/ci/ci-run.sh
@@ -26,8 +26,7 @@
 # PUSH_BINARY_ARCHIVE_EMAIL: used as author's email in binary archive commit
 # PUSH_BINARY_ARCHIVE_NAME: used as author's name in binary archive commit
 # SSH_PRIVATE_KEY: private key used to push binary archives
-# REVNG_ORCHESTRA_URL:
-#   alternative URL from where orchestra is installed (passed to pip install)
+# REVNG_ORCHESTRA_URL: orchestra git repo URL (must be git+ssh:// or git+https://)
 
 set -e
 set -x
@@ -80,7 +79,13 @@ set -x
 # Install orchestra
 #
 if test -n "$REVNG_ORCHESTRA_URL"; then
-    pip3 install --user "$REVNG_ORCHESTRA_URL"
+    # COMPONENT_TARGET_BRANCH is not quoted on purpose -- if empty it has to be ignored instead of being expanded to
+    # and empty string
+    for REVNG_ORCHESTRA_TARGET_BRANCH in $COMPONENT_TARGET_BRANCH next-develop develop next-master master; do
+        if pip3 install --user "$REVNG_ORCHESTRA_URL@$REVNG_ORCHESTRA_TARGET_BRANCH"; then
+            break
+        fi
+    done
 else
     pip3 install --user revng-orchestra
 fi


### PR DESCRIPTION
This PR is needed to:

- fix the CI triggerer. Gitlab enforces environment variables to be strings and is throwing HTTP 500 errors.
- install orchestra using the same logic used to pick the config and component branches