### PR TITLE
Windows builds

### DIFF
--- a/.orchestra/config/components.yml
+++ b/.orchestra/config/components.yml
@@ -2,6 +2,7 @@
 
 #! Do not push upstream components defined here.
 #! You should define them in a separate file and use overlay annotations.
+min_orchestra_version: "3.1.0"
 components: {}
 add_to_path:
   - $ORCHESTRA_ROOT/link-only/bin

--- a/.orchestra/config/components/boost.yml
+++ b/.orchestra/config/components/boost.yml
@@ -5,7 +5,7 @@
 
 #@yaml/text-templated-strings
 ---
-#@ def boost():
+#@ def boost(is_windows):
 license: LICENSE_1_0.txt
 configure: |
   mkdir -p "$BUILD_DIR"
@@ -16,14 +16,47 @@ configure: |
 install: |
   cd "$BUILD_DIR"
 
-  ./b2 \
-    --prefix="${DESTDIR}${ORCHESTRA_ROOT}" \
-    --ignore-site-config toolset='clang'
+  (@- if is_windows: @)
+
+  echo "using clang : : x86_64-w64-mingw32-clang++ -pthread -stdlib=libc++ -D_WIN32_WINNT=0x6000 -D_LIBCPP_HAS_THREAD_API_WIN32 -fvisibility-inlines-hidden -fvisibility=hidden -fgnuc-version=4.8.0 : ;" > user-config.jam
 
   ./b2 \
-    --prefix="${DESTDIR}${ORCHESTRA_ROOT}" \
-    --ignore-site-config toolset='clang' \
+    --user-config=user-config.jam \
+    --with-test \
+    --prefix="${DESTDIR}${ORCHESTRA_ROOT}/x86_64-w64-mingw32" \
+    --ignore-site-config \
+    address-model=64 \
+    architecture=x86 \
+    variant=release \
+    link=shared \
+    toolset=clang \
+    target-os=windows
+
+  ./b2 \
+    --user-config=user-config.jam \
+    --with-test \
+    --prefix="${DESTDIR}${ORCHESTRA_ROOT}/x86_64-w64-mingw32" \
+    --ignore-site-config \
+    address-model=64 \
+    architecture=x86 \
+    variant=release \
+    link=shared \
+    toolset=clang \
+    target-os=windows \
     install
+
+  (@- else: @)
+
+   ./b2 \
+     --prefix="${DESTDIR}${ORCHESTRA_ROOT}" \
+     --ignore-site-config toolset='clang'
+
+   ./b2 \
+     --prefix="${DESTDIR}${ORCHESTRA_ROOT}" \
+     --ignore-site-config toolset='clang' \
+     install
+
+  (@- end @)
 
 build_dependencies:
   - host-cxx-toolchain
@@ -37,4 +70,5 @@ dependencies:
 #@overlay/match-child-defaults missing_ok=True
 ---
 components:
-  boost: #@ single_build_component(**boost())
+  boost: #@ single_build_component(**boost(False))
+  windows/boost: #@ single_build_component(**boost(True))

--- a/.orchestra/config/components/clang_release.yml
+++ b/.orchestra/config/components/clang_release.yml
@@ -6,9 +6,9 @@
 
 ---
 #@ def cmake_opts():
-- -DLLVM_ENABLE_PROJECTS="clang;compiler-rt;libcxxabi;libcxx;clang-tools-extra"
-- -DBUILD_SHARED_LIBS=OFF
-- -DLLVM_ENABLE_ZLIB=OFF
+-DLLVM_ENABLE_PROJECTS: "clang;compiler-rt;libcxxabi;libcxx;clang-tools-extra"
+-DBUILD_SHARED_LIBS: "OFF"
+-DLLVM_ENABLE_ZLIB: "OFF"
 #@ end
 
 #@yaml/text-templated-strings

--- a/.orchestra/config/components/clang_release.yml
+++ b/.orchestra/config/components/clang_release.yml
@@ -6,7 +6,7 @@
 
 ---
 #@ def cmake_opts():
--DLLVM_ENABLE_PROJECTS: "clang;compiler-rt;libcxxabi;libcxx;clang-tools-extra"
+-DLLVM_ENABLE_PROJECTS: "clang;compiler-rt;libcxxabi;libcxx;clang-tools-extra;lld"
 -DBUILD_SHARED_LIBS: "OFF"
 -DLLVM_ENABLE_ZLIB: "OFF"
 #@ end

--- a/.orchestra/config/components/glib.yml
+++ b/.orchestra/config/components/glib.yml
@@ -4,10 +4,11 @@
 #@ load("/lib/ninja.lib.yml", "ninja")
 
 #@ source_url = "https://download.gnome.org/sources/glib/2.64/glib-2.64.5.tar.xz"
+#@ proxy_libintl_url = "https://github.com/frida/proxy-libintl/archive/refs/tags/0.1.tar.gz"
 
 #@yaml/text-templated-strings
 ---
-#@ def glib_args():
+#@ def glib_args(is_windows):
 license: source/COPYING
 configure: |
   mkdir -p "$BUILD_DIR/source"
@@ -16,13 +17,51 @@ configure: |
   sed -i 's|^.*HAVE_LANGINFO_.*1.*$||' "$BUILD_DIR/source/meson.build"
   sed -i -e '/subdir.*tests/d' "$BUILD_DIR"/source/{.,gio,glib}/meson.build
 
-  CC=clang \
-  CXX=clang++ \
+  (@- if is_windows: @)
+
+  extract.sh --into "$BUILD_DIR/source/subprojects/proxy-libintl" (@= proxy_libintl_url @)
+
+  export CC=x86_64-w64-mingw32-clang
+  export CXX=x86_64-w64-mingw32-clang++
+
+  echo "
+  [binaries]
+  c = 'x86_64-w64-mingw32-gcc'
+  cpp = 'x86_64-w64-mingw32-g++'
+  ranlib = 'x86_64-w64-mingw32-ranlib'
+  ar = 'x86_64-w64-mingw32-ar'
+  strip = 'x86_64-w64-mingw32-strip'
+  pkgconfig = 'x86_64-w64-mingw32-pkg-config'
+  windres = 'x86_64-w64-mingw32-windres'
+
+  [properties]
+  needs_exe_wrapper = true
+
+  [host_machine]
+  system = 'windows'
+  cpu_family = 'x86_64'
+  cpu = 'x86_64'
+  endian = 'little'
+  " > windows.meson
+
+  (@- else: @)
+
+  export CC=clang
+  export CXX=clang++
+
+  (@- end @)
+
   meson setup \
+    (@- if is_windows: @)
+    --cross-file windows.meson \
+    --prefix "$ORCHESTRA_ROOT/x86_64-w64-mingw32" \
+    -Dlibelf=disabled \
+    (@- else: @)
+    --prefix "$ORCHESTRA_ROOT" \
+    (@- end @)
+    --wrap-mode nodownload \
     --buildtype plain \
     --libdir=lib \
-    --prefix "$ORCHESTRA_ROOT" \
-    --wrap-mode nodownload \
     -Ddefault_library=shared \
     -Dselinux=disabled \
     -Dxattr=false \
@@ -54,4 +93,5 @@ dependencies:
 #@overlay/match-child-defaults missing_ok=True
 ---
 components:
-  glib: #@ single_build_component(**glib_args())
+  glib: #@ single_build_component(**glib_args(False))
+  windows/glib: #@ single_build_component(**glib_args(True))

--- a/.orchestra/config/components/libffi.yml
+++ b/.orchestra/config/components/libffi.yml
@@ -6,7 +6,7 @@
 
 #@yaml/text-templated-strings
 ---
-#@ def libffi_args():
+#@ def libffi_args(is_windows):
 license: LICENSE
 configure: |
   mkdir -p "$BUILD_DIR"
@@ -14,11 +14,16 @@ configure: |
 
   cd "$BUILD_DIR"
   ./configure \
+    (@- if is_windows: @)
+    --host=x86_64-w64-mingw32 \
+    --prefix="$ORCHESTRA_ROOT/x86_64-w64-mingw32" \
+    (@- else: @)
+    --prefix="$ORCHESTRA_ROOT" \
+    (@- end @)
     --disable-multi-os-directory \
     --disable-static \
     --disable-pax_emutramp \
-    --disable-debug \
-    --prefix="$ORCHESTRA_ROOT"
+    --disable-debug
 build_system: make
 build_dependencies:
   - host-c-toolchain
@@ -29,4 +34,5 @@ build_dependencies:
 #@overlay/match-child-defaults missing_ok=True
 ---
 components:
-  libffi: #@ single_build_component(**libffi_args())
+  libffi: #@ single_build_component(**libffi_args(False))
+  windows/libffi: #@ single_build_component(**libffi_args(True))

--- a/.orchestra/config/components/llvm.yml
+++ b/.orchestra/config/components/llvm.yml
@@ -5,13 +5,10 @@
 #@ load("/lib/fn_args.lib.yml", "mandatory")
 #@ load("/lib/ninja.lib.yml", "ninja")
 
-#@yaml/text-templated-strings
 ---
 #@ def cmake_opts():
-- -DBUILD_SHARED_LIBS=ON
-- -DLLVM_ENABLE_PROJECTS="clang"
-- -DCMAKE_C_COMPILER="(@= data.values.regular_c_compiler @)"
-- -DCMAKE_CXX_COMPILER="(@= data.values.regular_cxx_compiler @)"
+-DBUILD_SHARED_LIBS: "ON"
+-DLLVM_ENABLE_PROJECTS: "clang"
 #@ end
 
 #@yaml/text-templated-strings
@@ -26,7 +23,7 @@ builds:
     #@ cflags = f_options["extra_compiler_flags"]
     #@ ndebug = f_options["ndebug"]
     (@= flavor @):
-      configure: #@ configure_llvm(cmake_build_type=build_type, cflags=cflags, additional_cmake_options=cmake_opts(), source_dir="$SOURCE_DIR")
+      configure: #@ configure_llvm(cmake_build_type=build_type, cflags=cflags, additional_cmake_options=all_cmake_opts, source_dir="$SOURCE_DIR")
       install: |
         cd "$BUILD_DIR"
         (@= ninja @) install

--- a/.orchestra/config/components/llvm.yml
+++ b/.orchestra/config/components/llvm.yml
@@ -1,6 +1,7 @@
 #@ load("@ytt:data", "data")
 #@ load("@ytt:overlay", "overlay")
 #@ load("/components/llvm_common.lib.yml", "configure_llvm")
+#@ load("/lib/assert.lib.yml", "assert")
 #@ load("/lib/optimization_flavors.lib.yml", "typical_project_flavors")
 #@ load("/lib/fn_args.lib.yml", "mandatory")
 #@ load("/lib/ninja.lib.yml", "ninja")
@@ -13,7 +14,31 @@
 
 #@yaml/text-templated-strings
 ---
-#@ def llvm_component(use_asan=False):
+#@ def additional_windows_cmake_opts():
+-DCMAKE_C_COMPILER: x86_64-w64-mingw32-clang
+-DCMAKE_CXX_COMPILER: x86_64-w64-mingw32-clang++
+-DCMAKE_CXX_FLAGS: "-pthread -stdlib=libc++ -D_WIN32_WINNT=0x6000 -D_LIBCPP_HAS_THREAD_API_WIN32 -fvisibility-inlines-hidden -fvisibility=hidden -fuse-ld=lld"
+-DCMAKE_INSTALL_PREFIX: "$ORCHESTRA_ROOT/x86_64-w64-mingw32"
+-DCMAKE_SKIP_RPATH: "ON"
+-DCMAKE_SYSTEM_NAME: "Windows"
+-DWIN32: "ON"
+-DWIN32_TARGET_REVNG: "ON"
+-DLLVM_DEFAULT_TARGET_TRIPLE: "x86_64-linux-gnu"
+-DLLVM_ENABLE_Z3_SOLVER: "OFF"
+-DLLVM_BUILD_EXAMPLES: "OFF"
+-DLLVM_INCLUDE_EXAMPLES: "OFF"
+-DLLVM_BUILD_TESTS: "OFF"
+-DLLVM_INCLUDE_TESTS: "OFF"
+-DLLVM_ENABLE_ZLIB: "OFF"
+-DLLVM_ENABLE_TERMINFO: "OFF"
+#@ end
+
+#@yaml/text-templated-strings
+---
+#@ def llvm_component(platform=mandatory, use_asan=False):
+#@ assert(platform in ["linux", "windows"])
+#@ all_cmake_opts = dict(cmake_opts())
+
 repository: llvm-project
 license: llvm/LICENSE.TXT
 default_build: optimized
@@ -23,7 +48,11 @@ builds:
     #@ cflags = f_options["extra_compiler_flags"]
     #@ ndebug = f_options["ndebug"]
     (@= flavor @):
-      configure: #@ configure_llvm(cmake_build_type=build_type, cflags=cflags, additional_cmake_options=all_cmake_opts, source_dir="$SOURCE_DIR")
+      #@ if platform == "windows":
+      #@   all_cmake_opts.update(dict(additional_windows_cmake_opts()))
+      #@ end
+      configure: |
+        (@= configure_llvm(cmake_build_type=build_type, cflags=cflags, additional_cmake_options=all_cmake_opts, source_dir="$SOURCE_DIR") @)
       install: |
         cd "$BUILD_DIR"
         (@= ninja @) install
@@ -33,10 +62,14 @@ builds:
         if test "$RUN_TESTS" -eq 1; then
           (@= ninja @) check-all
         fi
-
+        (@- if platform == "windows": @)
+        ln -s ../../x86_64-w64-mingw32/usr/bin/libwinpthread-1.dll "${TMP_ROOT}${ORCHESTRA_ROOT}/win64/bin/"
+        (@ end -@)
       build_dependencies:
         - cmake
         - host-cxx-toolchain
+        #@ if/end platform == "windows":
+        - toolchain/win64/gcc
       dependencies:
         - host-libcxx
         - libunwind
@@ -49,4 +82,5 @@ builds:
 #@overlay/match-child-defaults missing_ok=True
 ---
 components:
-  llvm: #@ llvm_component()
+  llvm: #@ llvm_component(platform="linux")
+  windows/llvm: #@ llvm_component(platform="windows")

--- a/.orchestra/config/components/llvm.yml
+++ b/.orchestra/config/components/llvm.yml
@@ -31,12 +31,7 @@ builds:
         cd "$BUILD_DIR"
         (@= ninja @) install
 
-        CLANG_RELEASE_IDX="$ORCHESTRA_ROOT/share/orchestra/clang-release.idx"
-        if [ -e "$CLANG_RELEASE_IDX" ]; then
-          cat "$CLANG_RELEASE_IDX" | while read f; do
-            rm "${TMP_ROOT}${ORCHESTRA_ROOT}/$f" || true
-          done
-        fi
+        remove-files-from-other-component.sh clang-release "${TMP_ROOT}${ORCHESTRA_ROOT}"
 
         if test "$RUN_TESTS" -eq 1; then
           (@= ninja @) check-all

--- a/.orchestra/config/components/llvm_common.lib.yml
+++ b/.orchestra/config/components/llvm_common.lib.yml
@@ -3,30 +3,41 @@
 #@ load("/lib/shell.lib.yml", "expand_args")
 #@ load("/lib/cmake.lib.yml", "cmake")
 
+---
+#@ def _default_cmake_options(cmake_build_type, cflags):
+-DCMAKE_BUILD_RPATH: "\\$ORIGIN/../lib:$ORCHESTRA_ROOT/lib"
+-DCMAKE_INSTALL_RPATH: "$RPATH_PLACEHOLDER/lib"
+-DCMAKE_BUILD_TYPE: #@ cmake_build_type
+-DCMAKE_EXE_LINKER_FLAGS: #@ cflags
+-DCMAKE_SHARED_LINKER_FLAGS: #@ cflags
+-DCMAKE_MODULE_LINKER_FLAGS: #@ cflags
+-DCMAKE_CXX_FLAGS: #@ cflags
+-DLLVM_TARGETS_TO_BUILD: "AArch64;AMDGPU;ARM;Mips;SystemZ;X86"
+-DLLVM_ENABLE_DUMP: "ON"
+-DLLVM_ENABLE_TERMINFO: "OFF"
+-DLIBCXX_ENABLE_ABI_LINKER_SCRIPT: "OFF"
+-DLLVM_ENABLE_Z3_SOLVER: "OFF"
+-DLLVM_INCLUDE_GO_TESTS: "OFF"
+-DCMAKE_GENERATOR: "Ninja"
+#@ end
+
+---
+#@ def default_cmake_options(*args):
+#@ return dict(_default_cmake_options(*args))
+#@ end
+
+
 #@yaml/text-templated-strings
 ---
 #@ def _configure_llvm(cmake_build_type=mandatory, cflags=mandatory, additional_cmake_options=mandatory, source_dir="$SOURCE_DIR"):
+#@ cmake_opts = default_cmake_options(cmake_build_type, cflags)
+#@ cmake_opts.update(additional_cmake_options)
 - |
   mkdir -p "$BUILD_DIR"
   cd "$BUILD_DIR";
-  (@= cmake @) \
+  (@= cmake(additional_cmake_args=cmake_opts) @) \
     "(@= source_dir @)/llvm" \
-    -GNinja \
-    -DCMAKE_BUILD_RPATH="\$ORIGIN/../lib:$ORCHESTRA_ROOT/lib" \
-    -DCMAKE_INSTALL_RPATH="$RPATH_PLACEHOLDER/lib" \
-    -DCMAKE_BUILD_TYPE="(@= cmake_build_type @)" \
-    -DCMAKE_EXE_LINKER_FLAGS="(@= cflags @)" \
-    -DCMAKE_SHARED_LINKER_FLAGS="(@= cflags @)" \
-    -DCMAKE_MODULE_LINKER_FLAGS="(@= cflags @)" \
-    -DCMAKE_CXX_FLAGS="(@= cflags @)" \
-    -DLLVM_TARGETS_TO_BUILD="AArch64;AMDGPU;ARM;Mips;SystemZ;X86" \
-    -DLLVM_ENABLE_DUMP=ON \
-    -DLLVM_ENABLE_TERMINFO=OFF \
-    -DLIBCXX_ENABLE_ABI_LINKER_SCRIPT=OFF \
     -DCMAKE_CXX_STANDARD=20 \
-    -DLLVM_ENABLE_Z3_SOLVER=OFF \
-    -DLLVM_INCLUDE_GO_TESTS=OFF \
-    (@= expand_args(additional_cmake_options) @) \
     -Wno-dev
 #@ end
 

--- a/.orchestra/config/components/qemu.yml
+++ b/.orchestra/config/components/qemu.yml
@@ -5,7 +5,7 @@
 
 #@yaml/text-templated-strings
 ---
-#@ def qemu_component(use_asan=False):
+#@ def qemu_component(is_windows, use_asan=False):
 repository: qemu
 license: LICENSE
 default_build: optimized
@@ -19,11 +19,21 @@ builds:
         mkdir -p "$BUILD_DIR"
         cd "$BUILD_DIR";
         "$SOURCE_DIR/configure" \
+          (@- if is_windows: @)
+          --cc="x86_64-w64-mingw32-clang" \
+          --cross-prefix="x86_64-w64-mingw32-" \
+          --prefix="$ORCHESTRA_ROOT/x86_64-w64-mingw32" \
+          --target-list="arm-libtinycode aarch64-libtinycode i386-libtinycode mips-libtinycode mipsel-libtinycode s390x-libtinycode x86_64-libtinycode" \
+          --extra-cflags="(@= cflags @)" \
+          --extra-ldflags="-Wl,--start-group -lmman -shared" \
+          --disable-stack-protector \
+          (@- else: @)
           --cc="(@= data.values.regular_c_compiler @)" \
           --prefix="$ORCHESTRA_ROOT" \
-          --target-list=" arm-libtinycode arm-linux-user aarch64-libtinycode aarch64-linux-user i386-libtinycode i386-linux-user mips-libtinycode mips-linux-user mipsel-libtinycode mipsel-linux-user s390x-libtinycode s390x-linux-user x86_64-libtinycode x86_64-linux-user " \
+          --target-list="arm-libtinycode arm-linux-user arm-llvmhelpers aarch64-libtinycode aarch64-linux-user aarch64-llvmhelpers i386-libtinycode i386-linux-user i386-llvmhelpers mips-libtinycode mips-linux-user mips-llvmhelpers mipsel-libtinycode mipsel-linux-user mipsel-llvmhelpers s390x-libtinycode s390x-linux-user s390x-llvmhelpers x86_64-libtinycode x86_64-linux-user x86_64-llvmhelpers" \
+          --extra-cflags="(@= cflags @)" \
+          (@- end @)
           --disable-werror \
-          --enable-llvm-helpers \
           --disable-kvm \
           --without-pixman \
           --disable-tools \
@@ -33,11 +43,12 @@ builds:
           --disable-gnutls \
           --disable-smartcard-nss \
           --disable-uuid \
+          --disable-cap-ng \
           --python="$(which python2)" \
-          (@ if build_type == "Debug": @)--enable-debug (@ end @)\
-          --extra-cflags="(@= cflags @)"
+          (@ if build_type == "Debug": @)--enable-debug (@ end @)
       install: |
         cd "$BUILD_DIR"
+        mkdir -p "${DESTDIR}${ORCHESTRA_ROOT}/x86_64-w64-mingw32/include"
         (@= make @) install
       build_dependencies:
         - host-c-toolchain
@@ -45,6 +56,7 @@ builds:
         - glibc
         - llvm
       dependencies:
+        #@ if/end not is_windows:
         - zlib
         - glib
       #@ if/end ndebug == False:
@@ -56,4 +68,5 @@ builds:
 #@overlay/match-child-defaults missing_ok=True
 ---
 components:
-  qemu: #@ qemu_component()
+  qemu: #@ qemu_component(False)
+  windows/qemu: #@ qemu_component(True)

--- a/.orchestra/config/components/revng.yml
+++ b/.orchestra/config/components/revng.yml
@@ -2,7 +2,7 @@
 #@ load("/lib/cmake.lib.yml", "cmake_boost_configuration", "typical_cmake_builds")
 
 ---
-#@ def build_args():
+#@ def build_args(is_windows):
 test: true
 extra_cmake_args: #@ cmake_boost_configuration
 build_dependencies:
@@ -17,6 +17,7 @@ dependencies:
   - boost
   - clang-release
 use_asan: false
+is_windows: #@ is_windows
 #@ end
 
 #@overlay/match by=overlay.all, expects=1
@@ -27,4 +28,9 @@ components:
     repository: revng
     license: LICENSE.md
     default_build: optimized
-    builds: #@ typical_cmake_builds(**build_args())
+    builds: #@ typical_cmake_builds(**build_args(False))
+  windows/revng:
+    repository: revng
+    license: LICENSE.md
+    default_build: optimized
+    builds: #@ typical_cmake_builds(**build_args(True))

--- a/.orchestra/config/components/revng_qa.yml
+++ b/.orchestra/config/components/revng_qa.yml
@@ -2,6 +2,17 @@
 #@ load("/lib/create_component.lib.yml", "single_build_component")
 #@ load("/lib/cmake.lib.yml", "cmake")
 
+---
+#@ def cmake_args():
+-DTRIPLE_x86_64: "x86_64-gentoo-linux-musl"
+-DTRIPLE_mips: "mips-unknown-linux-musl"
+-DTRIPLE_mipsel: "mipsel-unknown-linux-musl"
+-DTRIPLE_i386: "i386-gentoo-linux-musl"
+-DTRIPLE_arm: "armv7a-hardfloat-linux-uclibceabi"
+-DTRIPLE_aarch64: "aarch64-unknown-linux-musl"
+-DTRIPLE_s390x: "s390x-ibm-linux-musl"
+#@ end
+
 #@yaml/text-templated-strings
 ---
 #@ def revng_qa_args():
@@ -9,16 +20,9 @@ repository: revng-qa
 license: LICENSE
 configure: |
   mkdir -p "$BUILD_DIR"
-  cd "$BUILD_DIR"; \
-  (@= cmake @) \
-    "$SOURCE_DIR" \
-    -DTRIPLE_x86_64="x86_64-gentoo-linux-musl" \
-    -DTRIPLE_mips="mips-unknown-linux-musl" \
-    -DTRIPLE_mipsel="mipsel-unknown-linux-musl" \
-    -DTRIPLE_i386="i386-gentoo-linux-musl" \
-    -DTRIPLE_arm="armv7a-hardfloat-linux-uclibceabi" \
-    -DTRIPLE_aarch64="aarch64-unknown-linux-musl" \
-    -DTRIPLE_s390x="s390x-ibm-linux-musl"
+  cd "$BUILD_DIR"
+  (@= cmake(additional_cmake_args=cmake_args()) @) \
+    "$SOURCE_DIR"
 build_system: make
 build_dependencies:
   - cmake

--- a/.orchestra/config/components/toolchain/arch/win32.yml
+++ b/.orchestra/config/components/toolchain/arch/win32.yml
@@ -15,6 +15,7 @@ extra_gcc_configure_options:
   - --disable-libssp
   - --disable-shared
 dynamic: "0"
+custom_pkgconfig: true
 #@ end
 
 #@overlay/match by=overlay.all, expects=1

--- a/.orchestra/config/components/toolchain/arch/win64.yml
+++ b/.orchestra/config/components/toolchain/arch/win64.yml
@@ -14,7 +14,7 @@ extra_gcc_configure_options:
   - --without-isl
   - --disable-libsanitizer
   - --disable-libssp
-  - --disable-shared
+  - --enable-shared
 dynamic: "0"
 #@ end
 

--- a/.orchestra/config/components/toolchain/arch/win64.yml
+++ b/.orchestra/config/components/toolchain/arch/win64.yml
@@ -17,6 +17,7 @@ extra_gcc_configure_options:
   - --enable-shared
 extra_gcc_stage2_configure_options: " --enable-threads=posix --enable-libstdcxx-threads=yes"
 dynamic: "0"
+custom_pkgconfig: true
 #@ end
 
 #@overlay/match by=overlay.all, expects=1

--- a/.orchestra/config/components/toolchain/arch/win64.yml
+++ b/.orchestra/config/components/toolchain/arch/win64.yml
@@ -15,6 +15,7 @@ extra_gcc_configure_options:
   - --disable-libsanitizer
   - --disable-libssp
   - --enable-shared
+extra_gcc_stage2_configure_options: " --enable-threads=posix --enable-libstdcxx-threads=yes"
 dynamic: "0"
 #@ end
 

--- a/.orchestra/config/components/toolchain/arch/win64.yml
+++ b/.orchestra/config/components/toolchain/arch/win64.yml
@@ -1,5 +1,6 @@
 #@ load("@ytt:overlay", "overlay")
 #@ load("/components/toolchain/lib/toolchain.lib.yml", "create_toolchain_components")
+#@ load("/lib/util.lib.yml", "datavalue")
 
 #@ def params():
 toolchain_name: win64
@@ -7,7 +8,7 @@ triple: x86_64-w64-mingw32
 binutils_version: "2.35"
 gdb_version: "8.2.1"
 mingw64_version: "6.0.0"
-gcc_version: "7.3.0"
+gcc_version: #@ str(datavalue("gcc_host_version"))
 extra_gcc_configure_options:
   - --without-cloog
   - --without-isl

--- a/.orchestra/config/components/toolchain/lib/binutils.lib.yml
+++ b/.orchestra/config/components/toolchain/lib/binutils.lib.yml
@@ -14,6 +14,7 @@
 #@   ):
 #@   source_url = "https://ftp.gnu.org/gnu/binutils/binutils-" + binutils_version + ".tar.bz2"
 #@   binutils_sysroot = binutils_sysroot or "$ORCHESTRA_ROOT/" + triple
+#@   bindir = "${ORCHESTRA_ROOT}/x86_64-pc-linux-gnu/" + triple + "/binutils-bin/" + binutils_version
 license: COPYING
 configure: |
   extract.sh --into "$SOURCE_DIR" (@= source_url @)
@@ -27,7 +28,7 @@ configure: |
     --datadir=$ORCHESTRA_ROOT/share/binutils-data/(@= triple @)/(@= binutils_version @) \
     --infodir=$ORCHESTRA_ROOT/share/binutils-data/(@= triple @)/(@= binutils_version @)/info \
     --mandir=$ORCHESTRA_ROOT/share/binutils-data/(@= triple @)/(@= binutils_version @)/man \
-    --bindir=$ORCHESTRA_ROOT/x86_64-pc-linux-gnu/(@= triple @)/binutils-bin/(@= binutils_version @) \
+    --bindir=(@= bindir @) \
     --libdir=$ORCHESTRA_ROOT/lib64/binutils/(@= triple @)/(@= binutils_version @) \
     --libexecdir=$ORCHESTRA_ROOT/lib64/binutils/(@= triple @)/(@= binutils_version @) \
     --includedir=$ORCHESTRA_ROOT/lib64/binutils/(@= triple @)/(@= binutils_version @)/include \
@@ -53,7 +54,7 @@ configure: |
     CXXFLAGS="-w -ggdb3 -O3"
 build_system: make
 add_to_path:
-  - ${ORCHESTRA_ROOT}/x86_64-pc-linux-gnu/(@= triple @)/binutils-bin/(@= binutils_version @)
+  - #@ bindir
 build_dependencies:
   - glibc
   - toolchain/host/gcc

--- a/.orchestra/config/components/toolchain/lib/gcc.lib.yml
+++ b/.orchestra/config/components/toolchain/lib/gcc.lib.yml
@@ -12,10 +12,10 @@
 #@ def gcc_dependencies(stage, toolchain_name, musl_version, uclibc_version, linux_version, mingw64_version):
 #@ if stage == 1:
 #@   suffixes = ["-headers"]
-#@   mingw_builds = ["@headers"]
+#@   mingw_suffixes = ["-headers"]
 #@ elif stage == 2:
 #@   suffixes = ["-headers", "-extra-libraries"]
-#@   mingw_builds = [""]
+#@   mingw_suffixes = ["-headers", "-base", "-extra-libraries"]
 #@ else:
 #@   fail("GCC stage must be 1 or 2")
 #@ end
@@ -38,8 +38,8 @@
 #@ end
 
 #@ if mingw64_version:
-#@ for build in mingw_builds:
-- toolchain/(@= toolchain_name @)/mingw64(@= build @)
+#@ for suffix in mingw_suffixes:
+- toolchain/(@= toolchain_name @)/mingw64(@= suffix @)
 #@ end
 #@ end
 
@@ -76,6 +76,7 @@
 #@    linux_version=None,
 #@    mingw64_version=None,
 #@    extra_gcc_configure_options="",
+#@    extra_gcc_stage2_configure_options="",
 #@    gcc_sysroot = None,
 #@    extra_gcc_make_variables = "",
 #@  ):
@@ -87,7 +88,8 @@
 #@ if stage == 1:
 #@    build_specific_configure_options = "--enable-languages=c"
 #@ elif stage == 2:
-#@    build_specific_configure_options = "--enable-languages=c,c++"
+#@    build_specific_configure_options = "--enable-languages=c,c++ " + extra_gcc_stage2_configure_options
+#@    build_specific_configure_options = build_specific_configure_options.strip()
 #@ else:
 #@   fail("GCC stage must be 1 or 2")
 #@ end

--- a/.orchestra/config/components/toolchain/lib/gcc.lib.yml
+++ b/.orchestra/config/components/toolchain/lib/gcc.lib.yml
@@ -79,6 +79,7 @@
 #@    extra_gcc_stage2_configure_options="",
 #@    gcc_sysroot = None,
 #@    extra_gcc_make_variables = "",
+#@    binutils_version = None,
 #@  ):
 
 #@    source_url = "https://ftp.gnu.org/gnu/gcc/gcc-" + gcc_version + "/gcc-" + gcc_version + ".tar.gz"
@@ -95,6 +96,10 @@
 #@ end
 #@ dependencies = gcc_dependencies(stage, toolchain_name, musl_version, uclibc_version, linux_version, mingw64_version) or []
 #@ build_dependencies = gcc_build_dependencies(stage, toolchain_name) or []
+
+#@ if "win" in toolchain_name:
+#@   binutils_bindir = "${ORCHESTRA_ROOT}/x86_64-pc-linux-gnu/" + triple + "/binutils-bin/" + binutils_version
+#@ end
 
 #! The sed is required to make `--sysroot=/` work with `--with-gxx-include-dir`
 #! properly.
@@ -197,7 +202,11 @@ install: |
 
   # Fixinclude locates the wrong pthread.h
   find "${DESTDIR}${ORCHESTRA_ROOT}" -type d -name include-fixed -exec rm -f {}/pthread.h \;
-
+  (@- if "win" in toolchain_name: @)
+  # Symlink needed for making windres use the right gcc
+  mkdir -p "${TMP_ROOT}(@= binutils_bindir @)"
+  ln -s "../../gcc-bin/(@= gcc_version @)/(@= triple @)-gcc" "${TMP_ROOT}(@= binutils_bindir @)/(@= triple @)-gcc"
+  (@ end -@)
 dependencies: #@ dependencies
 build_dependencies: #@ build_dependencies
 #@ end

--- a/.orchestra/config/components/toolchain/lib/gcc.lib.yml
+++ b/.orchestra/config/components/toolchain/lib/gcc.lib.yml
@@ -9,7 +9,7 @@
 
 #@yaml/text-templated-strings
 ---
-#@ def gcc_dependencies(stage, toolchain_name, musl_version, uclibc_version, linux_version, mingw64_version):
+#@ def gcc_dependencies(stage, toolchain_name, musl_version, uclibc_version, linux_version, mingw64_version, custom_pkgconfig):
 #@ if stage == 1:
 #@   suffixes = ["-headers"]
 #@   mingw_suffixes = ["-headers"]
@@ -45,6 +45,10 @@
 
 #@ if linux_version:
 - toolchain/(@= toolchain_name @)/linux-headers
+
+#@ if/end custom_pkgconfig:
+- toolchain/(@= toolchain_name @)/pkgconfig
+
 #@ end
 
 #@ end
@@ -80,6 +84,7 @@
 #@    gcc_sysroot = None,
 #@    extra_gcc_make_variables = "",
 #@    binutils_version = None,
+#@    custom_pkgconfig = False,
 #@  ):
 
 #@    source_url = "https://ftp.gnu.org/gnu/gcc/gcc-" + gcc_version + "/gcc-" + gcc_version + ".tar.gz"
@@ -94,7 +99,7 @@
 #@ else:
 #@   fail("GCC stage must be 1 or 2")
 #@ end
-#@ dependencies = gcc_dependencies(stage, toolchain_name, musl_version, uclibc_version, linux_version, mingw64_version) or []
+#@ dependencies = gcc_dependencies(stage, toolchain_name, musl_version, uclibc_version, linux_version, mingw64_version, custom_pkgconfig) or []
 #@ build_dependencies = gcc_build_dependencies(stage, toolchain_name) or []
 
 #@ if "win" in toolchain_name:

--- a/.orchestra/config/components/toolchain/lib/gcc.lib.yml
+++ b/.orchestra/config/components/toolchain/lib/gcc.lib.yml
@@ -11,9 +11,11 @@
 ---
 #@ def gcc_dependencies(stage, toolchain_name, musl_version, uclibc_version, linux_version, mingw64_version):
 #@ if stage == 1:
-#@   build = "~headers"
+#@   suffixes = ["-headers"]
+#@   mingw_builds = ["@headers"]
 #@ elif stage == 2:
-#@   build = ""
+#@   suffixes = ["-headers", "-extra-libraries"]
+#@   mingw_builds = [""]
 #@ else:
 #@   fail("GCC stage must be 1 or 2")
 #@ end
@@ -23,28 +25,41 @@
 - toolchain/host/binutils
 #@ end
 
-#@ if/end musl_version:
-- toolchain/(@= toolchain_name @)/musl(@= build @)
-#@ if/end uclibc_version:
-- toolchain/(@= toolchain_name @)/uclibc(@= build @)
-#@ if/end mingw64_version:
-- toolchain/(@= toolchain_name @)/mingw64(@= build @)
+#@ if musl_version:
+#@ for suffix in suffixes:
+- toolchain/(@= toolchain_name @)/musl(@= suffix @)
+#@ end
+#@ end
 
-#@ if/end linux_version:
+#@ if uclibc_version:
+#@ for suffix in suffixes:
+- toolchain/(@= toolchain_name @)/uclibc(@= suffix @)
+#@ end
+#@ end
+
+#@ if mingw64_version:
+#@ for build in mingw_builds:
+- toolchain/(@= toolchain_name @)/mingw64(@= build @)
+#@ end
+#@ end
+
+#@ if linux_version:
 - toolchain/(@= toolchain_name @)/linux-headers
+#@ end
+
 #@ end
 
 #@yaml/text-templated-strings
 ---
 #@ def gcc_build_dependencies(stage, toolchain_name):
-
-#@ if/end stage == 2 and "host" not in toolchain_name:
-- toolchain/(@= toolchain_name @)/gcc~stage1
-
 - glibc
 - gmp
 - mpfr
 - mpc
+
+#@ if stage == 2 and "host" not in toolchain_name:
+- toolchain/(@= toolchain_name @)/gcc~stage1
+#@ end
 
 #@ end
 

--- a/.orchestra/config/components/toolchain/lib/mingw64.lib.yml
+++ b/.orchestra/config/components/toolchain/lib/mingw64.lib.yml
@@ -3,74 +3,125 @@
 #@ load("/lib/make.lib.yml", "make")
 #@ load("/lib/fn_args.lib.yml", "mandatory")
 #@ load("/lib/assert.lib.yml", "assert")
+#@ load("/lib/create_component.lib.yml", "single_build_component")
 
 #@ load("/components/toolchain/lib/common.lib.yml", "new_gcc_path")
 
 
 #@yaml/text-templated-strings
 ---
-#@ def mingw64_build(
-#@    triple=mandatory,
-#@    gcc_version=mandatory,
-#@    mingw64_version=mandatory,
-#@    build_type=mandatory,
-#@  ):
-
-#@ assert(build_type in ["headers", "default"])
-#@ source_url = "https://downloads.sourceforge.net/project/mingw-w64/mingw-w64/mingw-w64-release/mingw-w64-v" + mingw64_version + ".tar.bz2"
-
-configure: |
-  extract.sh --into "$BUILD_DIR" "(@= source_url @)"
-  cd "$BUILD_DIR"
-  (@ if build_type == "default": @)
-  NEW_GCC_PATH="(@= new_gcc_path(triple=triple, gcc_version=gcc_version) @)"
-  NEW_GCC=${NEW_GCC_PATH}/(@= triple @)-gcc
-  export CC="${NEW_GCC}"
-  export CPPFLAGS="-I${ORCHESTRA_ROOT}/(@= triple @)/usr/include"
-  export CHOST="(@= triple @)"
-  (@ end -@)
-  "$BUILD_DIR/configure" \
-    --disable-silent-rules \
-    --target=(@= triple @) \
-    --with-sysroot=no \
-    --prefix="$ORCHESTRA_ROOT/(@= triple @)/usr" \
-    --with-headers \
-    --enable-sdk \
-    --without-libraries \
-    --without-tools \
-    (@- if build_type == "default": @)
-    --with-crt \
-    --host=(@= triple @) \
-    --disable-idl \
-    $($NEW_GCC -E -dM - < /dev/null | grep -q __MINGW64__ && echo --disable-lib32 --enable-lib64 || echo --enable-lib32 --disable-lib64)
-    (@- elif build_type == "headers": @)
-    --without-crt \
-    --without-idl
-    (@- end @)
-install: |
-  cd "$BUILD_DIR"
+#@ def common_install_script(triple=mandatory):
+- |
   (@= make @)
   (@= make @) install
   rm -f "${TMP_ROOT}${ORCHESTRA_ROOT}/(@= triple @)/mingw"
-  ln -s usr "${TMP_ROOT}${ORCHESTRA_ROOT}/(@= triple @)/mingw"
+  ln -s . "${TMP_ROOT}${ORCHESTRA_ROOT}/(@= triple @)/mingw"
   rm -f "${TMP_ROOT}${ORCHESTRA_ROOT}/(@= triple @)/(@= triple @)"
-  ln -s usr "${TMP_ROOT}${ORCHESTRA_ROOT}/(@= triple @)/(@= triple @)"
-  rm -f usr/include "${TMP_ROOT}${ORCHESTRA_ROOT}/(@= triple @)/sys-include"
-  ln -s usr/include "${TMP_ROOT}${ORCHESTRA_ROOT}/(@= triple @)/sys-include"
-
-#@ if/end build_type == "default":
-dependencies:
-  - toolchain/win64/gcc~stage1
-  - toolchain/win64/mingw64~headers
-
+  ln -s . "${TMP_ROOT}${ORCHESTRA_ROOT}/(@= triple @)/(@= triple @)"
+  rm -f "${TMP_ROOT}${ORCHESTRA_ROOT}/(@= triple @)/sys-include"
+  ln -s ./include "${TMP_ROOT}${ORCHESTRA_ROOT}/(@= triple @)/sys-include"
 #@ end
 
 #@yaml/text-templated-strings
 ---
-#@ def create_mingw64_component(toolchain_name=mandatory, **kwargs):
-license: COPYING
-default_build: default
-builds:
-  headers: #@ mingw64_build(build_type="headers", **kwargs)
-  default: #@ mingw64_build(build_type="default", **kwargs)
+#@ def mingw64_flavors(
+#@    toolchain_name=mandatory,
+#@    triple=mandatory,
+#@    gcc_version=mandatory,
+#@    mingw64_version=mandatory,
+#@    build_type=mandatory,
+#@ ):
+#@ source_url = "https://downloads.sourceforge.net/project/mingw-w64/mingw-w64/mingw-w64-release/mingw-w64-v" + mingw64_version + ".tar.bz2"
+headers:
+  configure: |
+    extract.sh --into "$BUILD_DIR" "(@= source_url @)"
+    cd "$BUILD_DIR/mingw-w64-headers"
+    ./configure \
+      --disable-silent-rules \
+      --target=(@= triple @) \
+      --host=(@= triple @) \
+      --build=x86_64-gentoo-linux-musl \
+      --prefix="$ORCHESTRA_ROOT/(@= triple @)" \
+      --enable-sdk \
+      --enable-secure-api
+  install: |
+    cd "$BUILD_DIR/mingw-w64-headers"
+    (@= common_install_script(triple)[0] @)
+
+base:
+  configure: |
+    extract.sh --into "$BUILD_DIR" "(@= source_url @)"
+    cd "$BUILD_DIR"
+    NEW_GCC_PATH="(@= new_gcc_path(triple=triple, gcc_version=gcc_version) @)"
+    NEW_GCC=${NEW_GCC_PATH}/(@= triple @)-gcc
+    export CC="${NEW_GCC}"
+    export CPPFLAGS="-I${ORCHESTRA_ROOT}/(@= triple @)/include"
+    export CHOST="(@= triple @)"
+
+    ./configure \
+      --disable-silent-rules \
+      --target=(@= triple @) \
+      --host=(@= triple @) \
+      --build=x86_64-gentoo-linux-musl \
+      --prefix="$ORCHESTRA_ROOT/(@= triple @)" \
+      --enable-sdk \
+      --enable-secure-api \
+      --with-sysroot=no \
+      --with-headers \
+      --with-crt \
+      --without-libraries \
+      $($NEW_GCC -E -dM - < /dev/null | grep -q __MINGW64__ && echo --disable-lib32 --enable-lib64 || echo --enable-lib32 --disable-lib64)
+  install: |
+    cd "$BUILD_DIR"
+    (@= common_install_script(triple)[0] @)
+    # Remove files already installed by mingw64-headers
+    remove-files-from-other-component.sh "toolchain/(@= toolchain_name @)/mingw64-headers" "${TMP_ROOT}${ORCHESTRA_ROOT}"
+  dependencies:
+    - toolchain/(@= toolchain_name @)/gcc~stage1
+    - toolchain/(@= toolchain_name @)/mingw64-headers
+
+extra-libraries:
+  configure: |
+    extract.sh --into "$BUILD_DIR" "(@= source_url @)"
+    cd "$BUILD_DIR"
+    NEW_GCC_PATH="(@= new_gcc_path(triple=triple, gcc_version=gcc_version) @)"
+    NEW_GCC=${NEW_GCC_PATH}/(@= triple @)-gcc
+    export CC="${NEW_GCC}"
+    export CPPFLAGS="-I${ORCHESTRA_ROOT}/(@= triple @)/include"
+    export CHOST="(@= triple @)"
+
+    ./configure \
+      --disable-silent-rules \
+      --target=(@= triple @) \
+      --host=(@= triple @) \
+      --build=x86_64-gentoo-linux-musl \
+      --prefix="$ORCHESTRA_ROOT/(@= triple @)" \
+      --enable-sdk \
+      --enable-secure-api \
+      --with-sysroot=no \
+      --with-headers \
+      --with-crt \
+      --with-libraries=winpthreads \
+      $($NEW_GCC -E -dM - < /dev/null | grep -q __MINGW64__ && echo --disable-lib32 --enable-lib64 || echo --enable-lib32 --disable-lib64)
+  install: |
+    cd "$BUILD_DIR"
+    (@= common_install_script(triple)[0] @)
+
+    mkdir -p "${TMP_ROOT}${ORCHESTRA_ROOT}/(@= toolchain_name @)/bin/"
+    ln -s ../../(@= triple @)/usr/bin/libwinpthread-1.dll "${TMP_ROOT}${ORCHESTRA_ROOT}/(@= toolchain_name @)/bin/"
+
+    # Remove files already installed by mingw64-headers and mingw64-base
+    remove-files-from-other-component.sh "toolchain/(@= toolchain_name @)/mingw64-headers" "${TMP_ROOT}${ORCHESTRA_ROOT}"
+    remove-files-from-other-component.sh "toolchain/(@= toolchain_name @)/mingw64-base" "${TMP_ROOT}${ORCHESTRA_ROOT}"
+  dependencies:
+    - toolchain/(@= toolchain_name @)/gcc~stage1
+    - toolchain/(@= toolchain_name @)/mingw64-base
+#@ end
+
+#@yaml/text-templated-strings
+---
+#@ def create_mingw64_components(toolchain_name=mandatory, **kwargs):
+#@ for type, options in dict(mingw64_flavors(toolchain_name=toolchain_name, **kwargs)).items():
+(@= "toolchain/" + toolchain_name + "/mingw64-" + type @): #@ single_build_component(license="COPYING", **options)
+#@ end
 #@ end

--- a/.orchestra/config/components/toolchain/lib/musl.lib.yml
+++ b/.orchestra/config/components/toolchain/lib/musl.lib.yml
@@ -4,7 +4,6 @@
 #@ load("/lib/make.lib.yml", "make", "serial_make")
 #@ load("/lib/fn_args.lib.yml", "mandatory")
 #@ load("/lib/optimization_flavors.lib.yml", "libc_optimization_flavors")
-#@ load("/components/toolchain/lib/common.lib.yml", "new_gcc")
 
 #@yaml/text-templated-strings
 ---
@@ -23,7 +22,7 @@ configure: |
   extract.sh --into "$BUILD_DIR" "(@= source_url @)"
   patch-if-exists "${ORCHESTRA_DOTDIR}/patches/musl-(@= musl_version @)-printf-floating-point-rounding.patch" "$BUILD_DIR"
 
-  cd "$BUILD_DIR" && CC="(@= new_gcc(triple=triple, gcc_version=gcc_version) @)" CFLAGS=" (@= additional_cflags @)" "$BUILD_DIR/configure" \
+  cd "$BUILD_DIR" && CC="(@= triple @)-gcc" CFLAGS=" (@= additional_cflags @)" "$BUILD_DIR/configure" \
     --target=(@= triple @) \
     --prefix="$ORCHESTRA_ROOT/(@= triple @)/usr" \
     --syslibdir="$ORCHESTRA_ROOT/(@= triple @)/lib" \
@@ -32,8 +31,11 @@ install: |
   cd "$BUILD_DIR"
   (@= make @)
   (@= serial_make @) install
+
+  # Remove files already installed by musl-headers
+  remove-files-from-other-component.sh "toolchain/(@= toolchain_name @)/musl-headers" "${TMP_ROOT}${ORCHESTRA_ROOT}"
 build_dependencies:
-  - toolchain/(@= toolchain_name @)/gcc~stage1
+  - toolchain/(@= toolchain_name @)/gcc
 #@ end
 
 #@yaml/text-templated-strings
@@ -62,17 +64,22 @@ configure: |
 
 #@yaml/text-templated-strings
 ---
-#@ def create_musl_component(
+#@ def create_musl_components(
 #@      triple=mandatory,
 #@      musl_version=mandatory,
 #@      toolchain_name=mandatory,
 #@      gcc_version=mandatory
 #@ ):
-license: COPYRIGHT
-default_build: default
-builds:
-  headers: #@ musl_headers(triple=triple, musl_version=musl_version, toolchain_name=toolchain_name)
-  #@ for flavor, flags in libc_optimization_flavors.items():
-  (@= flavor @): #@ musl_build(triple=triple, musl_version=musl_version, toolchain_name=toolchain_name, additional_cflags=flags, gcc_version=gcc_version)
-  #@ end
+toolchain/(@= toolchain_name @)/musl-headers:
+  license: COPYRIGHT
+  builds:
+    default: #@ musl_headers(triple=triple, musl_version=musl_version, toolchain_name=toolchain_name)
+
+toolchain/(@= toolchain_name @)/musl-extra-libraries:
+  license: COPYRIGHT
+  default_build: default
+  builds:
+    #@ for flavor, flags in libc_optimization_flavors.items():
+    (@= flavor @): #@ musl_build(triple=triple, musl_version=musl_version, toolchain_name=toolchain_name, additional_cflags=flags, gcc_version=gcc_version)
+    #@ end
 #@ end

--- a/.orchestra/config/components/toolchain/lib/pkgconfig.lib.yml
+++ b/.orchestra/config/components/toolchain/lib/pkgconfig.lib.yml
@@ -1,0 +1,31 @@
+#@yaml/text-templated-strings
+
+#@ load("/lib/fn_args.lib.yml", "mandatory")
+#@ load("/lib/create_component.lib.yml", "single_build_component")
+
+#@yaml/text-templated-strings
+---
+#@ def pkgconfig_args(
+#@        triple=mandatory,
+#@ ):
+configure: |
+  mkdir -p "$BUILD_DIR"
+  # Nothing else to do
+install: |
+  mkdir -p "${TMP_ROOT}${ORCHESTRA_ROOT}/(@= triple @)/bin"
+  cat >> "${TMP_ROOT}${ORCHESTRA_ROOT}/(@= triple @)/bin/(@= triple @)-pkg-config" << EOF
+  #!/bin/bash
+  DIR="\$( cd "\$( dirname "\${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+  export PKG_CONFIG_PATH="\$DIR/../lib/pkgconfig"
+  export PKG_CONFIG_LIBDIR="\$DIR/../lib/pkgconfig"
+  exec pkg-config "\$@"
+  EOF
+  chmod +x "${TMP_ROOT}${ORCHESTRA_ROOT}/(@= triple @)/bin/(@= triple @)-pkg-config"
+add_to_path:
+  - $ORCHESTRA_ROOT/(@= triple @)/bin
+#@ end
+
+---
+#@ def create_pkgconfig_component(toolchain_name=mandatory, triple=mandatory):
+#@ return single_build_component(**pkgconfig_args(triple=triple))
+#@ end

--- a/.orchestra/config/components/toolchain/lib/toolchain.lib.yml
+++ b/.orchestra/config/components/toolchain/lib/toolchain.lib.yml
@@ -47,7 +47,7 @@
 (@= "toolchain/" + toolchain_name + "/linux-headers" @): #@ create_linux_headers_component(triple=triple, linux_version=linux_version, arch_name=linux_arch_name)
 
 #@ if/end gcc_version:
-(@= "toolchain/" + toolchain_name + "/gcc" @): #@ create_gcc_component(toolchain_name=toolchain_name, triple=triple, gcc_sysroot=gcc_sysroot, gcc_version=gcc_version, extra_gcc_configure_options=extra_gcc_configure_options, extra_gcc_stage2_configure_options=extra_gcc_stage2_configure_options, extra_gcc_make_variables=extra_gcc_make_variables, musl_version=musl_version, uclibc_version=uclibc_version, linux_version=linux_version, mingw64_version=mingw64_version)
+(@= "toolchain/" + toolchain_name + "/gcc" @): #@ create_gcc_component(toolchain_name=toolchain_name, triple=triple, gcc_sysroot=gcc_sysroot, gcc_version=gcc_version, extra_gcc_configure_options=extra_gcc_configure_options, extra_gcc_stage2_configure_options=extra_gcc_stage2_configure_options, extra_gcc_make_variables=extra_gcc_make_variables, musl_version=musl_version, uclibc_version=uclibc_version, linux_version=linux_version, mingw64_version=mingw64_version, binutils_version=binutils_version)
 
 #@ if/end mingw64_version:
 _: #@ template.replace(create_mingw64_components(toolchain_name=toolchain_name, triple=triple, mingw64_version=mingw64_version, gcc_version=gcc_version))

--- a/.orchestra/config/components/toolchain/lib/toolchain.lib.yml
+++ b/.orchestra/config/components/toolchain/lib/toolchain.lib.yml
@@ -11,6 +11,7 @@
 #@ load("/components/toolchain/lib/coreutils.lib.yml", "create_coreutils_component")
 #@ load("/components/toolchain/lib/mingw64.lib.yml", "create_mingw64_components")
 #@ load("/components/toolchain/lib/spec.lib.yml", "create_spec_components")
+#@ load("/components/toolchain/lib/pkgconfig.lib.yml", "create_pkgconfig_component")
 
 #@yaml/text-templated-strings
 ---
@@ -35,6 +36,7 @@
 #@    extra_gcc_make_variables="",
 #@    dynamic=None,
 #@    spec=False,
+#@    custom_pkgconfig=False,
 #@ ):
 
 #@ if/end binutils_version:
@@ -47,7 +49,7 @@
 (@= "toolchain/" + toolchain_name + "/linux-headers" @): #@ create_linux_headers_component(triple=triple, linux_version=linux_version, arch_name=linux_arch_name)
 
 #@ if/end gcc_version:
-(@= "toolchain/" + toolchain_name + "/gcc" @): #@ create_gcc_component(toolchain_name=toolchain_name, triple=triple, gcc_sysroot=gcc_sysroot, gcc_version=gcc_version, extra_gcc_configure_options=extra_gcc_configure_options, extra_gcc_stage2_configure_options=extra_gcc_stage2_configure_options, extra_gcc_make_variables=extra_gcc_make_variables, musl_version=musl_version, uclibc_version=uclibc_version, linux_version=linux_version, mingw64_version=mingw64_version, binutils_version=binutils_version)
+(@= "toolchain/" + toolchain_name + "/gcc" @): #@ create_gcc_component(toolchain_name=toolchain_name, triple=triple, gcc_sysroot=gcc_sysroot, gcc_version=gcc_version, extra_gcc_configure_options=extra_gcc_configure_options, extra_gcc_stage2_configure_options=extra_gcc_stage2_configure_options, extra_gcc_make_variables=extra_gcc_make_variables, musl_version=musl_version, uclibc_version=uclibc_version, linux_version=linux_version, mingw64_version=mingw64_version, binutils_version=binutils_version, custom_pkgconfig=custom_pkgconfig)
 
 #@ if/end mingw64_version:
 _: #@ template.replace(create_mingw64_components(toolchain_name=toolchain_name, triple=triple, mingw64_version=mingw64_version, gcc_version=gcc_version))
@@ -63,5 +65,8 @@ _: #@ template.replace(create_uclibc_components(triple=triple, toolchain_name=to
 
 #@ if/end spec:
 _: #@ template.replace(create_spec_components(triple=triple, toolchain_name=toolchain_name))
+
+#@ if/end custom_pkgconfig:
+toolchain/(@= toolchain_name @)/pkgconfig: #@ create_pkgconfig_component(triple=triple, toolchain_name=toolchain_name)
 
 #@ end

--- a/.orchestra/config/components/toolchain/lib/toolchain.lib.yml
+++ b/.orchestra/config/components/toolchain/lib/toolchain.lib.yml
@@ -6,8 +6,8 @@
 #@ load("/components/toolchain/lib/binutils.lib.yml", "create_binutils_component")
 #@ load("/components/toolchain/lib/gdb.lib.yml", "create_gdb_component")
 #@ load("/components/toolchain/lib/gcc.lib.yml", "create_gcc_component")
-#@ load("/components/toolchain/lib/musl.lib.yml", "create_musl_component")
-#@ load("/components/toolchain/lib/uclibc.lib.yml", "create_uclibc_component")
+#@ load("/components/toolchain/lib/musl.lib.yml", "create_musl_components")
+#@ load("/components/toolchain/lib/uclibc.lib.yml", "create_uclibc_components")
 #@ load("/components/toolchain/lib/coreutils.lib.yml", "create_coreutils_component")
 #@ load("/components/toolchain/lib/mingw64.lib.yml", "create_mingw64_component")
 #@ load("/components/toolchain/lib/spec.lib.yml", "create_spec_components")
@@ -52,13 +52,13 @@
 (@= "toolchain/" + toolchain_name + "/mingw64" @): #@ create_mingw64_component(toolchain_name=toolchain_name, triple=triple, mingw64_version=mingw64_version, gcc_version=gcc_version)
 
 #@ if/end musl_version:
-(@= "toolchain/" + toolchain_name + "/musl" @): #@ create_musl_component(triple=triple, musl_version=musl_version, toolchain_name=toolchain_name, gcc_version=gcc_version)
+_: #@ template.replace(create_musl_components(triple=triple, musl_version=musl_version, toolchain_name=toolchain_name, gcc_version=gcc_version))
 
 #@ if/end coreutils_version:
 (@= "toolchain/" + toolchain_name + "/coreutils" @): #@ create_coreutils_component(triple=triple, coreutils_version=coreutils_version)
 
 #@ if/end uclibc_version:
-(@= "toolchain/" + toolchain_name + "/uclibc" @): #@ create_uclibc_component(triple=triple, toolchain_name=toolchain_name, uclibc_version=uclibc_version, uclibc_arch_name=uclibc_arch_name, gcc_version=gcc_version, binutils_version=binutils_version)
+_: #@ template.replace(create_uclibc_components(triple=triple, toolchain_name=toolchain_name, uclibc_version=uclibc_version, uclibc_arch_name=uclibc_arch_name, gcc_version=gcc_version, binutils_version=binutils_version))
 
 #@ if/end spec:
 _: #@ template.replace(create_spec_components(triple=triple, toolchain_name=toolchain_name))

--- a/.orchestra/config/components/toolchain/lib/toolchain.lib.yml
+++ b/.orchestra/config/components/toolchain/lib/toolchain.lib.yml
@@ -9,7 +9,7 @@
 #@ load("/components/toolchain/lib/musl.lib.yml", "create_musl_components")
 #@ load("/components/toolchain/lib/uclibc.lib.yml", "create_uclibc_components")
 #@ load("/components/toolchain/lib/coreutils.lib.yml", "create_coreutils_component")
-#@ load("/components/toolchain/lib/mingw64.lib.yml", "create_mingw64_component")
+#@ load("/components/toolchain/lib/mingw64.lib.yml", "create_mingw64_components")
 #@ load("/components/toolchain/lib/spec.lib.yml", "create_spec_components")
 
 #@yaml/text-templated-strings
@@ -30,6 +30,7 @@
 #@    binutils_sysroot=None,
 #@    mingw64_version=None,
 #@    extra_gcc_configure_options=None,
+#@    extra_gcc_stage2_configure_options="",
 #@    extra_binutils_configure_options=None,
 #@    extra_gcc_make_variables="",
 #@    dynamic=None,
@@ -46,10 +47,10 @@
 (@= "toolchain/" + toolchain_name + "/linux-headers" @): #@ create_linux_headers_component(triple=triple, linux_version=linux_version, arch_name=linux_arch_name)
 
 #@ if/end gcc_version:
-(@= "toolchain/" + toolchain_name + "/gcc" @): #@ create_gcc_component(toolchain_name=toolchain_name, triple=triple, gcc_sysroot=gcc_sysroot, gcc_version=gcc_version, extra_gcc_configure_options=extra_gcc_configure_options, extra_gcc_make_variables=extra_gcc_make_variables, musl_version=musl_version, uclibc_version=uclibc_version, linux_version=linux_version, mingw64_version=mingw64_version)
+(@= "toolchain/" + toolchain_name + "/gcc" @): #@ create_gcc_component(toolchain_name=toolchain_name, triple=triple, gcc_sysroot=gcc_sysroot, gcc_version=gcc_version, extra_gcc_configure_options=extra_gcc_configure_options, extra_gcc_stage2_configure_options=extra_gcc_stage2_configure_options, extra_gcc_make_variables=extra_gcc_make_variables, musl_version=musl_version, uclibc_version=uclibc_version, linux_version=linux_version, mingw64_version=mingw64_version)
 
 #@ if/end mingw64_version:
-(@= "toolchain/" + toolchain_name + "/mingw64" @): #@ create_mingw64_component(toolchain_name=toolchain_name, triple=triple, mingw64_version=mingw64_version, gcc_version=gcc_version)
+_: #@ template.replace(create_mingw64_components(toolchain_name=toolchain_name, triple=triple, mingw64_version=mingw64_version, gcc_version=gcc_version))
 
 #@ if/end musl_version:
 _: #@ template.replace(create_musl_components(triple=triple, musl_version=musl_version, toolchain_name=toolchain_name, gcc_version=gcc_version))

--- a/.orchestra/config/components/toolchain/lib/uclibc.lib.yml
+++ b/.orchestra/config/components/toolchain/lib/uclibc.lib.yml
@@ -33,14 +33,13 @@ configure: |
   true | (@= serial_make @) oldconfig
   sed 's|^typedef __kernel_dev_t\s*__kernel_old_dev_t;$|\0\ntypedef long __kernel_long_t;\ntypedef unsigned long __kernel_ulong_t;|' libc/sysdeps/linux/arm/bits/kernel_types.h -i
 install: |
-  export PATH="
-      (@-= new_gcc_path(triple=triple, gcc_version=gcc_version) @):
-      (@-= binutils_path(triple=triple, binutils_version=binutils_version) -@)
-      :$PATH"
   (@= serial_make @) -C "$BUILD_DIR"
   (@= serial_make @) -C "$BUILD_DIR" install DESTDIR="${DESTDIR}${ORCHESTRA_ROOT}/(@= triple @)"
+
+  # Remove files already installed by uclibc-headers
+  remove-files-from-other-component.sh "toolchain/(@= toolchain_name @)/uclibc-headers" "${TMP_ROOT}${ORCHESTRA_ROOT}"
 build_dependencies:
-  - toolchain/(@= toolchain_name @)/gcc~stage1
+  - toolchain/(@= toolchain_name @)/gcc
 #@ end
 
 #@yaml/text-templated-strings
@@ -54,24 +53,28 @@ install: |
   (@= serial_make @) DESTDIR="${DESTDIR}${ORCHESTRA_ROOT}/(@= triple @)" install_headers
 #@overlay/remove
 build_dependencies:
-  - toolchain/(@= toolchain_name @)/gcc~stage1
+  - toolchain/(@= toolchain_name @)/gcc
 #@ end
 
 #@yaml/text-templated-strings
 ---
-#@ def create_uclibc_component(**kwargs):
+#@ def create_uclibc_components(**kwargs):
 #@    toolchain_name = kwargs["toolchain_name"]
 #@    triple = kwargs["triple"]
 #@    uclibc_arch_name = kwargs["uclibc_arch_name"]
 #@    uclibc_version = kwargs["uclibc_version"]
 #@    gcc_version = kwargs["gcc_version"]
 #@    binutils_version = kwargs["binutils_version"]
+toolchain/(@= toolchain_name @)/uclibc-headers:
+  license: COPYING.LIB
+  builds:
+    default: #@ overlay.apply(uclibc_build(**kwargs), uclibc_headers_overlay(**kwargs))
 
-license: COPYING.LIB
-default_build: default
-builds:
-  headers: #@ overlay.apply(uclibc_build(**kwargs), uclibc_headers_overlay(**kwargs))
-  #@ for flavor, flags in libc_optimization_flavors.items():
-  (@= flavor @): #@ uclibc_build(additional_cflags=flags, **kwargs)
-  #@ end
+toolchain/(@= toolchain_name @)/uclibc-extra-libraries:
+  license: COPYING.LIB
+  default_build: default
+  builds:
+    #@ for flavor, flags in libc_optimization_flavors.items():
+    (@= flavor @): #@ uclibc_build(additional_cflags=flags, **kwargs)
+    #@ end
 #@ end

--- a/.orchestra/config/components/toolchain/macos/libtapi.yml
+++ b/.orchestra/config/components/toolchain/macos/libtapi.yml
@@ -1,4 +1,5 @@
 #@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:template", "template")
 
 #@ load("/lib/make.lib.yml", "make")
 #@ load("/lib/cmake.lib.yml", "cmake", "cmdline_cmake_base_configuration")
@@ -6,6 +7,12 @@
 
 #@ clang_source_url = "https://opensource.apple.com/tarballs/clang/clang-800.0.42.1.tar.gz"
 #@ libtapi_source_url = "https://opensource.apple.com/tarballs/tapi/tapi-1.30.tar.gz"
+
+---
+#@ def cmake_args():
+_: #@ template.replace(cmdline_cmake_base_configuration(cmake_generator="Unix Makefiles", cmake_build_type="Release"))
+-DLLVM_INCLUDE_TESTS: "OFF"
+#@ end
 
 #@yaml/text-templated-strings
 ---
@@ -22,10 +29,8 @@ builds:
 
       sed -i 's|NOT APPLE|FALSE|' src/projects/libtapi/CMakeLists.txt
       sed -i 's|^|#include <limits>\n|' src/projects/libtapi/include/tapi/Core/ArchitectureSupport.h
-      (@= cmake @) \
-        src/ \
-        (@= expand_args(cmdline_cmake_base_configuration(cmake_build_type="Release")) @) \
-        -DLLVM_INCLUDE_TESTS=OFF
+      (@= cmake(additional_cmake_args=cmake_args()) @) \
+        src/
     install: |
       cd "$BUILD_DIR"
       (@= make @) libtapi

--- a/.orchestra/config/components/toolchain/mman_win32.yml
+++ b/.orchestra/config/components/toolchain/mman_win32.yml
@@ -1,0 +1,26 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+#@ load("/lib/create_component.lib.yml", "single_build_component")
+#@ load("/lib/ninja.lib.yml", "ninja")
+
+#@ source_url = "https://github.com/alitrack/mman-win32/archive/2d1c576e62b99e85d99407e1a88794c6e44c3310.tar.gz"
+
+#@yaml/text-templated-strings
+---
+#@ def mman_win32_args():
+license: README.md
+configure: |
+  extract.sh --into "$BUILD_DIR" (@= source_url @)
+  cd "$BUILD_DIR"
+  ./configure \
+    --prefix="$ORCHESTRA_ROOT/x86_64-w64-mingw32" \
+    --enable-shared \
+    --cross-prefix=x86_64-w64-mingw32-
+build_system: make
+#@ end
+
+#@overlay/match by=overlay.all, expects=1
+#@overlay/match-child-defaults missing_ok=True
+---
+components:
+  mman-win32: #@ single_build_component(**mman_win32_args())

--- a/.orchestra/config/components/ui/cold_revng.yml
+++ b/.orchestra/config/components/ui/cold_revng.yml
@@ -11,10 +11,10 @@ pre_configure_script: |
     orc clone ui/qt-creator
   fi
 extra_cmake_args:
-  - #@ template.replace(cmake_boost_configuration)
+  _: #@ template.replace(cmake_boost_configuration)
   #! TODO: this is really ugly hack to get the same value of QTC_SOURCE as legacy orchestra
-  - -DQTC_SOURCE="$SOURCE_DIR/../qt-creator"
-  - -DQTC_BUILD="$ORCHESTRA_ROOT"
+  -DQTC_SOURCE: "$SOURCE_DIR/../qt-creator"
+  -DQTC_BUILD: "$ORCHESTRA_ROOT"
 build_dependencies:
   - cmake
   - glibc

--- a/.orchestra/config/components/ui/qt.yml
+++ b/.orchestra/config/components/ui/qt.yml
@@ -11,16 +11,6 @@
   mkdir -p "$BUILD_DIR"
   cd "$BUILD_DIR";
 
-  mkdir -p "$BUILD_DIR/bin"
-  cat > "$BUILD_DIR/bin/pmake" <<eof
-  #!/bin/sh
-  exec make -j$(nproc) $*
-  eof
-  chmod +x "$BUILD_DIR/bin/pmake"
-
-  export PATH=$BUILD_DIR/bin:$PATH
-
-  MAKE="pmake" \
   $SOURCE_DIR/configure \
     -recheck-all \
     -prefix "$ORCHESTRA_ROOT" \

--- a/.orchestra/config/components/ui/qt.yml
+++ b/.orchestra/config/components/ui/qt.yml
@@ -6,14 +6,13 @@
 
 #@yaml/text-templated-strings
 ---
-#@ def _configure_base(extra_qmake_options=""):
+#@ def _configure_base(is_windows, extra_qmake_options=""):
 - |
   mkdir -p "$BUILD_DIR"
   cd "$BUILD_DIR";
 
   $SOURCE_DIR/configure \
     -recheck-all \
-    -prefix "$ORCHESTRA_ROOT" \
     -confirm-license \
     -opensource \
     -skip qt3d \
@@ -47,21 +46,13 @@
     -skip qtwinextras  \
     -skip qtxmlpatterns  \
     -skip qtwebengine \
-    -openssl-runtime \
     -no-glib \
     -no-cups \
     -no-gtk \
     -qt-harfbuzz \
-    -fontconfig \
-    -system-freetype \
     -opengl desktop \
-    -egl \
-    -no-eglfs \
-    -xcb \
-    -xkbcommon \
     -no-icu \
     -no-zstd \
-    -libinput \
     -qt-libpng \
     -qt-libjpeg \
     -qt-sqlite \
@@ -74,19 +65,36 @@
     -nomake tests \
     -nomake examples \
     -c++std c++14 \
+    (@- if is_windows: @)
+    -prefix "$ORCHESTRA_ROOT/x86_64-w64-mingw32" \
+    -xplatform win32-clang-g++ \
+    -device-option CROSS_COMPILE=x86_64-w64-mingw32- \
+    QMAKE_CXXFLAGS+="-D_WIN32_WINNT=0x6000 -D_LIBCPP_HAS_THREAD_API_WIN32" \
+    QMAKE_LFLAGS+="-pthread" \
+    (@- else: @)
+    -prefix "$ORCHESTRA_ROOT" \
+    -openssl-runtime \
+    -fontconfig \
+    -system-freetype \
+    -egl \
+    -no-eglfs \
+    -xcb \
+    -xkbcommon \
+    -libinput \
     -platform linux-clang \
+    (@- end @)
     -no-pch \
     (@= extra_qmake_options @)
 #@ end
 
-#@ def configure_base(**kwargs):
-#@    return _configure_base(**kwargs)[0]
+#@ def configure_base(*args, **kwargs):
+#@    return _configure_base(*args, **kwargs)[0]
 #@ end
 
 
 #@yaml/text-templated-strings
 ---
-#@ def qt_component():
+#@ def qt_component(is_windows):
 license: LICENSE.GPLv3
 default_build: optimized
 builds:
@@ -100,24 +108,35 @@ builds:
 
       sed -i 's|QT_CONFIG(getauxval)|0|' "$SOURCE_DIR/qtbase/src/corelib/global/qrandom.cpp"
 
-      (@= configure_base(extra_qmake_options=extra_qmake_options) @)
+      (@= configure_base(is_windows, extra_qmake_options=extra_qmake_options) @)
     install: |
       cd "$BUILD_DIR"
 
       (@= make @)
       (@= make @) install INSTALL_ROOT=$TMP_ROOT
 
-      rm "${TMP_ROOT}${ORCHESTRA_ROOT}/lib64/cmake/Qt5Gui/Qt5GuiConfigExtras.cmake"
-      touch "${TMP_ROOT}${ORCHESTRA_ROOT}/lib64/cmake/Qt5Gui/Qt5GuiConfigExtras.cmake"
-      find "${TMP_ROOT}${ORCHESTRA_ROOT}" \( -name "*.pri" -or -name "*.pc" -or -name "*.pri"  \) \
+
+      (@ if is_windows: @)
+      mkdir -p "${TMP_ROOT}${ORCHESTRA_ROOT}/x86_64-w64-mingw32"
+      cd "${TMP_ROOT}${ORCHESTRA_ROOT}/x86_64-w64-mingw32"
+      cp -ar "${TMP_ROOT}${BUILD_DIR}/qtbase/bin/C:/Qt/"Qt-*/. .
+      LIBDIR=lib
+      (@ else: @)
+      LIBDIR=lib64
+      cd "${TMP_ROOT}${ORCHESTRA_ROOT}"
+      (@ end @)
+
+      rm "$LIBDIR/cmake/Qt5Gui/Qt5GuiConfigExtras.cmake"
+      touch "$LIBDIR/cmake/Qt5Gui/Qt5GuiConfigExtras.cmake"
+      find . \( -name "*.pri" -or -name "*.pc" -or -name "*.pri"  \) \
           -exec sed 's|/[^; ]*/lib\([^; ]*\)\.so|-l\1|g' {} -i ";"
 
-      cat > "${TMP_ROOT}${ORCHESTRA_ROOT}/bin/qt.conf" <<EOF
+      cat > "bin/qt.conf" <<EOF
       [Paths]
       Prefix = ..
       EOF
 
-      cd "${TMP_ROOT}${ORCHESTRA_ROOT}/mkspecs/linux-clang/"
+      cd "mkspecs/linux-clang/"
       mv "qmake.conf" "qmake.conf.tmp"
       grep -v ORCHESTRA_TMP "qmake.conf.tmp" > "qmake.conf"
       rm "qmake.conf.tmp"
@@ -151,4 +170,5 @@ builds:
 #@overlay/match-child-defaults missing_ok=True
 ---
 components:
-  ui/qt: #@ qt_component()
+  ui/qt: #@ qt_component(False)
+  windows/ui/qt: #@ qt_component(True)

--- a/.orchestra/config/components/ui/qt_creator.yml
+++ b/.orchestra/config/components/ui/qt_creator.yml
@@ -18,13 +18,20 @@
 
 #@yaml/text-templated-strings
 ---
-#@ def _configure_base(extra_qmake_args=[]):
+#@ def _configure_base(is_windows, extra_qmake_args=[]):
 #! TODO: In legacy orchestra QMAKE_RPATHDIR has +="" in debug and release but ="" in optimized. Is it intentional?
 - |
   mkdir -p "$BUILD_DIR"
   cd "$BUILD_DIR";
   qmake -r "$SOURCE_DIR" \
+    (@- if is_windows: @)
+    -spec win32-clang-g++ \
+    QMAKE_CXX=x86_64-w64-mingw32-clang++ \
+    QMAKE_CXXFLAGS+="-D_WIN32_WINNT=0x6000 -D_LIBCPP_HAS_THREAD_API_WIN32" \
+    QMAKE_LFLAGS+="-pthread" \
+    (@- else: @)
     -spec linux-clang \
+    (@- end @)
     DEFINES+="COLD_REVNG" \
     (@= expand_args(extra_qmake_args) @) \
     QMAKE_LFLAGS_RPATH= \
@@ -32,13 +39,13 @@
     ONLY_PLUGINS="(@= " ".join(qt_creator_plugins()) @)"
 #@ end
 
-#@ def configure_base(**kwargs):
-#@    return _configure_base(**kwargs)[0].strip()
+#@ def configure_base(*args, **kwargs):
+#@    return _configure_base(*args, **kwargs)[0].strip()
 #@ end
 
 #@yaml/text-templated-strings
 ---
-#@ def qt_creator_component():
+#@ def qt_creator_component(is_windows):
 repository: ui-qt-creator
 license: LICENSE.GPL3-EXCEPT
 default_build: optimized
@@ -46,11 +53,15 @@ builds:
   #@ for flavor, opts in qmake_optimization_flavors.items():
   #@ extra_qmake_args = opts["extra_qmake_args"]
   (@= flavor @):
-    configure: #@ configure_base(extra_qmake_args=extra_qmake_args)
+    configure: #@ configure_base(is_windows, extra_qmake_args=extra_qmake_args)
     install: |
       cd "$BUILD_DIR"
       (@= make @)
+      (@ if is_windows: @)
+      (@= make @) install INSTALL_ROOT="$DESTDIR$ORCHESTRA_ROOT/x86_64-w64-mingw32"
+      (@ else: @)
       (@= make @) install INSTALL_ROOT="$DESTDIR$ORCHESTRA_ROOT"
+      (@ end @)
     dependencies:
       - host-libcxx
       - llvm
@@ -67,4 +78,5 @@ builds:
 #@overlay/match-child-defaults missing_ok=True
 ---
 components:
-  ui/qt-creator: #@ qt_creator_component()
+  ui/qt-creator: #@ qt_creator_component(False)
+  windows/ui/qt-creator: #@ qt_creator_component(True)

--- a/.orchestra/config/components/ui/quickqanava.yml
+++ b/.orchestra/config/components/ui/quickqanava.yml
@@ -4,7 +4,7 @@
 ---
 #@ def build_args():
 extra_cmake_args:
-  - -DQML_PLUGIN_INSTALL_DIRECTORY="$ORCHESTRA_ROOT/qml"
+  -DQML_PLUGIN_INSTALL_DIRECTORY: "$ORCHESTRA_ROOT/qml"
 build_dependencies:
   - cmake
   - glibc

--- a/.orchestra/config/components/win-libcxx.yml
+++ b/.orchestra/config/components/win-libcxx.yml
@@ -1,0 +1,75 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+#@ load("/lib/create_component.lib.yml", "single_build_component")
+#@ load("/lib/ninja.lib.yml", "ninja")
+
+#@yaml/text-templated-strings
+---
+#@ def clang_release_args():
+#@    source_url = "https://github.com/llvm/llvm-project/archive/llvmorg-" + data.values.clang_release_version + ".tar.gz"
+license: source/llvm/LICENSE.TXT
+configure: |
+  extract.sh --into "$BUILD_DIR/source" "(@= source_url @)"
+  cd "$BUILD_DIR"
+  sed -i 's|GIT_FOUND|FALSE|g' "source/llvm/cmake/modules/VersionFromVCS.cmake"
+  patch-if-exists "${ORCHESTRA_DOTDIR}/patches/libcxxabi-add-has-win32-thread-api.patch" "$BUILD_DIR/source"
+install: |
+  cd "$BUILD_DIR"
+  mkdir -p libcxxabi
+  cd libcxxabi
+  cmake "$BUILD_DIR/source/libcxxabi" \
+    -GNinja \
+    -DCMAKE_INSTALL_PREFIX=$ORCHESTRA_ROOT/x86_64-w64-mingw32 \
+    -DCMAKE_SYSTEM_NAME=Windows \
+    -DCMAKE_CROSSCOMPILING=TRUE \
+    -DCMAKE_C_COMPILER=x86_64-w64-mingw32-clang \
+    -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-clang++ \
+    -DCMAKE_CXX_FLAGS="-U_LIBCPP_BUILDING_LIBRARY -D_LIBCPP_BUILDING_LIBRARY= -U_LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS -D_WIN32_WINNT=0x6000" \
+    -DLIBCXXABI_TARGET_TRIPLE=x86_64-w64-mingw32 \
+    -DLIBCXXABI_LIBCXX_INCLUDES="$BUILD_DIR/source/libcxx/include/" \
+    -DLIBCXXABI_ENABLE_SHARED=OFF \
+    -DLIBCXXABI_ENABLE_EXCEPTIONS=ON \
+    -DLIBCXXABI_HAS_WIN32_THREAD_API=ON \
+    -DLIBCXXABI_ENABLE_NEW_DELETE_DEFINITIONS=OFF \
+    -DLIBCXXABI_HAS_CXA_THREAD_ATEXIT_IMPL=ON
+  ninja
+
+  cd ..
+  mkdir -p libcxx
+  cd libcxx
+  cmake "$BUILD_DIR/source/libcxx" \
+    -GNinja \
+    -DCMAKE_INSTALL_PREFIX=$ORCHESTRA_ROOT/x86_64-w64-mingw32 \
+    -DCMAKE_SYSTEM_NAME=Windows \
+    -DCMAKE_CROSSCOMPILING=TRUE \
+    -DCMAKE_C_COMPILER=x86_64-w64-mingw32-clang \
+    -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-clang++ \
+    -DCMAKE_CXX_FLAGS="-D_LIBCXXABI_BUILDING_LIBRARY -Wno-unused-command-line-argument -Wl,--start-group -D_WIN32_WINNT=0x6000" \
+    -DLIBCXX_TARGET_TRIPLE=x86_64-w64-mingw32 \
+    -DLIBCXX_HAS_WIN32_THREAD_API=ON \
+    -DLIBCXX_ENABLE_FILESYSTEM=OFF \
+    -DLIBCXX_CXX_ABI_LIBRARY_PATH="$BUILD_DIR/libcxxabi/lib" \
+    -DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=TRUE \
+    -DLIBCXX_CXX_ABI=libcxxabi \
+    -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$BUILD_DIR/source/libcxxabi/include" \
+    -DLIBCXX_ENABLE_EXCEPTIONS=ON
+  ninja
+
+  # ninja install
+
+  mkdir -p "${DESTDIR}${ORCHESTRA_ROOT}/x86_64-w64-mingw32/bin/"
+  cp -a "lib/libc++.dll" "${DESTDIR}${ORCHESTRA_ROOT}/x86_64-w64-mingw32/bin/"
+
+  mkdir -p "${DESTDIR}${ORCHESTRA_ROOT}/x86_64-w64-mingw32/lib/"
+  cp -a "lib/libc++.dll" "lib/libc++.dll.a" "${DESTDIR}${ORCHESTRA_ROOT}/x86_64-w64-mingw32/lib/"
+build_dependencies:
+  - cmake
+dependencies:
+  - toolchain/win64/gcc
+#@ end
+
+#@overlay/match by=overlay.all, expects=1
+#@overlay/match-child-defaults missing_ok=True
+---
+components:
+  windows/libcxx: #@ single_build_component(**clang_release_args())

--- a/.orchestra/config/components/zlib.yml
+++ b/.orchestra/config/components/zlib.yml
@@ -6,17 +6,41 @@
 
 #@yaml/text-templated-strings
 ---
-#@ def zlib_args():
+#@ def zlib_args(is_windows):
 license: README
 configure: |
   mkdir -p "$BUILD_DIR"
   extract.sh --into "$BUILD_DIR" (@= source_url @)
+  (@ if is_windows: @)
+  sed -i \
+    -e 's/PREFIX.*=.*/\0x86_64-w64-mingw32-/' \
+    -e 's/SHARED_MODE.*=.*0/SHARED_MODE=1/' \
+    -e 's/zlib1\.dll/libz.dll/g' \
+    "$BUILD_DIR/win32/Makefile.gcc"
+  (@ else: @)
   cd "$BUILD_DIR"
   ./configure \
     --shared \
     --uname=linux \
     --prefix="$ORCHESTRA_ROOT"
+  (@ end @)
+#@ if is_windows:
+install: |
+  cd "$BUILD_DIR"
+  (@ if is_windows: @)
+  make \
+    -f win32/Makefile.gcc \
+    install \
+    CFLAGS="-fno-stack-protector" \
+    BINARY_PATH=${ORCHESTRA_ROOT}/x86_64-w64-mingw32/bin \
+    LIBRARY_PATH=${ORCHESTRA_ROOT}/x86_64-w64-mingw32/lib \
+    INCLUDE_PATH=${ORCHESTRA_ROOT}/x86_64-w64-mingw32/include
+  (@ else: @)
+  make -j16
+  (@ end @)
+#@ else:
 build_system: make
+#@ end
 build_dependencies:
   - host-c-toolchain
   - glibc
@@ -26,4 +50,5 @@ build_dependencies:
 #@overlay/match-child-defaults missing_ok=True
 ---
 components:
-  zlib: #@ single_build_component(**zlib_args())
+  zlib: #@ single_build_component(**zlib_args(False))
+  windows/zlib: #@ single_build_component(**zlib_args(True))

--- a/.orchestra/config/lib/cmake.lib.yml
+++ b/.orchestra/config/lib/cmake.lib.yml
@@ -1,53 +1,71 @@
 #@ load("@ytt:data", "data")
 
+#@ load("/lib/assert.lib.yml", "assert")
 #@ load("/lib/fn_args.lib.yml", "mandatory")
 #@ load("/lib/shell.lib.yml", "expand_args")
 #@ load("/lib/optimization_flavors.lib.yml", "typical_cmake_flavors")
 
+---
+#@ def default_cmake_args():
+-DCMAKE_EXPORT_COMPILE_COMMANDS: "ON"
+-DCMAKE_INSTALL_SO_NO_EXE: "0"
+-DCMAKE_INSTALL_PREFIX: "$ORCHESTRA_ROOT"
+#@ end
+
 #@yaml/text-templated-strings
 ---
-#@ def _cmake():
+#@ def _cmake(additional_cmake_args={}):
+#@ cmake_args = dict(default_cmake_args())
+#@ cmake_args.update(dict(additional_cmake_args))
 - |
   cmake \
-    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-    -DCMAKE_INSTALL_SO_NO_EXE=0 \
-    -DCMAKE_INSTALL_PREFIX="$ORCHESTRA_ROOT"
+    (@= expand_args(cmake_args) -@)
 #@ end
-#@ cmake = _cmake()[0].rstrip()
+
+---
+#@ def cmake(additional_cmake_args={}):
+#@ return _cmake(additional_cmake_args=additional_cmake_args)[0]
+#@ end
 
 #@yaml/text-templated-strings
 ---
 #@ def cmdline_cmake_base_configuration(
+#@        cmake_generator=mandatory,
 #@        cmake_build_type=mandatory,
 #@        extra_compiler_flags="",
 #@        extra_c_flags="",
 #@        extra_cxx_flags="",
 #@  ):
-- -DCMAKE_C_COMPILER="(@= data.values.regular_c_compiler @)"
-- -DCMAKE_CXX_COMPILER="(@= data.values.regular_cxx_compiler @)"
-- -DCMAKE_C_FLAGS="(@= extra_compiler_flags @) (@= extra_c_flags @)"
-- -DCMAKE_CXX_FLAGS="(@= extra_compiler_flags @) (@= extra_cxx_flags @)"
-- -DCMAKE_BUILD_RPATH="$RPATH_PLACEHOLDER/lib:$RPATH_PLACEHOLDER/(@= data.values.sanitizers_libs_path @):$RPATH_PLACEHOLDER/lib/revng/analyses"
-- -DCMAKE_INSTALL_RPATH="$RPATH_PLACEHOLDER/lib:$RPATH_PLACEHOLDER/(@= data.values.sanitizers_libs_path @):$RPATH_PLACEHOLDER/lib/revng/analyses"
-- -DCMAKE_BUILD_TYPE="(@= cmake_build_type @)"
+-DCMAKE_C_COMPILER: #@ data.values.regular_c_compiler
+-DCMAKE_CXX_COMPILER: #@ data.values.regular_cxx_compiler
+-DCMAKE_C_FLAGS: "(@= extra_compiler_flags @) (@= extra_c_flags @)"
+-DCMAKE_CXX_FLAGS: "(@= extra_compiler_flags @) (@= extra_cxx_flags @)"
+-DCMAKE_BUILD_RPATH: "$RPATH_PLACEHOLDER/lib:$RPATH_PLACEHOLDER/(@= data.values.sanitizers_libs_path @):$RPATH_PLACEHOLDER/lib/revng/analyses"
+-DCMAKE_INSTALL_RPATH: "$RPATH_PLACEHOLDER/lib:$RPATH_PLACEHOLDER/(@= data.values.sanitizers_libs_path @):$RPATH_PLACEHOLDER/lib/revng/analyses"
+-DCMAKE_BUILD_TYPE: #@ cmake_build_type
+-DCMAKE_GENERATOR: #@ cmake_generator
 #@ end
 
 ---
 
 #@ def _cmake_boost_configuration():
-- -DBOOST_ROOT="$ORCHESTRA_ROOT"
-- -DBoost_NO_BOOST_CMAKE=On
-- -DBoost_NO_SYSTEM_PATHS=On
+-DBOOST_ROOT: "$ORCHESTRA_ROOT"
+-DBoost_NO_BOOST_CMAKE: "On"
+-DBoost_NO_SYSTEM_PATHS: "On"
 #@ end
 
 #@ cmake_boost_configuration = _cmake_boost_configuration()
 
 ---
+#@ def build_system_to_cmake_generator():
+make: "Unix Makefiles"
+ninja: "Ninja"
+#@ end
 
 #@yaml/text-templated-strings
 ---
 #@ def typical_cmake_builds(
-#@        extra_cmake_args=[],
+#@        extra_cmake_args={},
 #@        build_system="Ninja",
 #@        dependencies=[],
 #@        build_dependencies=[],
@@ -59,26 +77,27 @@
 #@        post_install_script="",
 #@        test=False,
 #@ ):
+#@ build_system = build_system.lower()
+#@ assert(build_system in build_system_to_cmake_generator())
+#@ cmake_generator = build_system_to_cmake_generator()[build_system]
 
 #@ for flavor, opts in typical_cmake_flavors(use_asan=use_asan).items():
 (@= flavor @):
+  #@ additional_cmake_args = dict(cmdline_cmake_base_configuration(cmake_generator=cmake_generator, cmake_build_type=opts["cmake_build_type"], extra_compiler_flags=opts["extra_compiler_flags"]))
+  #@ additional_cmake_args.update(dict(extra_cmake_args))
   configure: |
     (@- if pre_configure_script: @)
     (@= pre_configure_script @)
     (@ end -@)
-
     (@- if source_url: @)
     extract.sh "(@= source_url @)"
     (@ end -@)
 
     mkdir -p "$BUILD_DIR"
 
-    cd "$BUILD_DIR";
-    (@= cmake @) \
-      "$SOURCE_DIR" \
-      -G"(@= build_system @)" \
-      (@= expand_args(cmdline_cmake_base_configuration(cmake_build_type=opts["cmake_build_type"], extra_compiler_flags=opts["extra_compiler_flags"])) @) \
-      (@= expand_args(extra_cmake_args) @)
+    cd "$BUILD_DIR"
+    (@= cmake(additional_cmake_args=additional_cmake_args) @) \
+      "$SOURCE_DIR"
 
     (@- if post_configure_script: @)
     (@= post_configure_script @)

--- a/.orchestra/config/lib/cmake.lib.yml
+++ b/.orchestra/config/lib/cmake.lib.yml
@@ -30,16 +30,28 @@
 #@yaml/text-templated-strings
 ---
 #@ def cmdline_cmake_base_configuration(
+#@        is_windows=mandatory,
 #@        cmake_generator=mandatory,
 #@        cmake_build_type=mandatory,
 #@        extra_compiler_flags="",
 #@        extra_c_flags="",
 #@        extra_cxx_flags="",
 #@  ):
+#@ if is_windows:
+-DCMAKE_C_COMPILER: x86_64-w64-mingw32-clang
+-DCMAKE_CXX_COMPILER: x86_64-w64-mingw32-clang++
+-DCMAKE_INSTALL_PREFIX: "$ORCHESTRA_ROOT/x86_64-w64-mingw32"
+-DCMAKE_PREFIX_PATH: "$ORCHESTRA_ROOT/x86_64-w64-mingw32"
+-DCMAKE_SKIP_RPATH: "ON"
+-DCMAKE_SYSTEM_NAME: "Windows"
+-DCMAKE_CROSSCOMPILING: "TRUE"
+-DCMAKE_CXX_FLAGS: "-pthread -stdlib=libc++ -D_WIN32_WINNT=0x6000 -D_LIBCPP_HAS_THREAD_API_WIN32 -fvisibility-inlines-hidden -fvisibility=hidden -fgnuc-version=4.8.0 -fuse-ld=lld (@= extra_compiler_flags @) (@= extra_cxx_flags @)"
+#@ else:
 -DCMAKE_C_COMPILER: #@ data.values.regular_c_compiler
 -DCMAKE_CXX_COMPILER: #@ data.values.regular_cxx_compiler
--DCMAKE_C_FLAGS: "(@= extra_compiler_flags @) (@= extra_c_flags @)"
 -DCMAKE_CXX_FLAGS: "(@= extra_compiler_flags @) (@= extra_cxx_flags @)"
+#@ end
+-DCMAKE_C_FLAGS: "(@= extra_compiler_flags @) (@= extra_c_flags @)"
 -DCMAKE_BUILD_RPATH: "$RPATH_PLACEHOLDER/lib:$RPATH_PLACEHOLDER/(@= data.values.sanitizers_libs_path @):$RPATH_PLACEHOLDER/lib/revng/analyses"
 -DCMAKE_INSTALL_RPATH: "$RPATH_PLACEHOLDER/lib:$RPATH_PLACEHOLDER/(@= data.values.sanitizers_libs_path @):$RPATH_PLACEHOLDER/lib/revng/analyses"
 -DCMAKE_BUILD_TYPE: #@ cmake_build_type
@@ -76,6 +88,7 @@ ninja: "Ninja"
 #@        pre_install_script="",
 #@        post_install_script="",
 #@        test=False,
+#@        is_windows=False,
 #@ ):
 #@ build_system = build_system.lower()
 #@ assert(build_system in build_system_to_cmake_generator())
@@ -83,7 +96,7 @@ ninja: "Ninja"
 
 #@ for flavor, opts in typical_cmake_flavors(use_asan=use_asan).items():
 (@= flavor @):
-  #@ additional_cmake_args = dict(cmdline_cmake_base_configuration(cmake_generator=cmake_generator, cmake_build_type=opts["cmake_build_type"], extra_compiler_flags=opts["extra_compiler_flags"]))
+  #@ additional_cmake_args = dict(cmdline_cmake_base_configuration(is_windows=is_windows, cmake_generator=cmake_generator, cmake_build_type=opts["cmake_build_type"], extra_compiler_flags=opts["extra_compiler_flags"]))
   #@ additional_cmake_args.update(dict(extra_cmake_args))
   configure: |
     (@- if pre_configure_script: @)

--- a/.orchestra/config/lib/shell.lib.yml
+++ b/.orchestra/config/lib/shell.lib.yml
@@ -1,19 +1,44 @@
+#@ load("/lib/assert.lib.yml", "fail")
+
+---
+#@ def is_dict_like(o):
+#@ return type(o) == "dict" or type(o) == "yamlfragment" and str(o) == "yamlfragment(*yamlmeta.Map)"
+#@ end
+
+---
+#@ def is_list_like(o):
+#@ return type(o) == "dict" or type(o) == "yamlfragment" and str(o) == "yamlfragment(*yamlmeta.Array)"
+#@ end
+
 #@yaml/text-templated-strings
 ---
-#@ def _expand_args(args_list):
+#@ def _expand_args_list(args_list):
 - |2
     (@ for arg in args_list: @)
     (@= arg @) \
     (@- end @)
 #@ end
 
+#@yaml/text-templated-strings
 ---
-#@ def expand_args(args_list):
-#@   if not args_list:
+#@ def _expand_args_dict(args_dict, sep="="):
+- |2
+    (@ for name, val in args_dict.items(): @)
+    (@= name @)(@= sep @)"(@= val @)" \
+    (@- end @)
+#@ end
+
+---
+#@ def expand_args(args, sep="="):
+#@   if not args:
 #@     return ""
-#@   elif type(args_list) in ["str", "string"]:
-#@     return args_list
+#@   elif type(args) == "string":
+#@     return args
+#@   elif is_dict_like(args):
+#@     return _expand_args_dict(dict(args), sep=sep)[0].strip().rstrip(" \\")
+#@   elif is_list_like(args):
+#@     return _expand_args_list(list(args))[0].strip().rstrip(" \\")
 #@   else:
-#@     return _expand_args(list(args_list))[0].strip().rstrip(" \\")
+#@     fail("Unexpected type " + type(args) + " given to expand_args")
 #@   end
 #@ end

--- a/.orchestra/patches/libcxxabi-add-has-win32-thread-api.patch
+++ b/.orchestra/patches/libcxxabi-add-has-win32-thread-api.patch
@@ -1,0 +1,78 @@
+From 05b3716ddbd536c130caa79cf8486f62548f05fc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Markus=20B=C3=B6ck?= <markus.boeck02@gmail.com>
+Date: Fri, 5 Mar 2021 15:30:13 +0100
+Subject: [PATCH] [libcxxabi] Add LIBCXXABI_HAS_WIN32_THREAD_API build option
+
+A few files in libc++abi make use of libc++ headers and a few of those use threading primitives provided by libc++. Since libc++ has multiple threading APIs it may be necessary to override auto-detection.
+
+This patch adds the LIBCXXABI_HAS_WIN32_THREAD_API which does roughly the same as LIBCXXABI_HAS_PTHREAD_API and the similarly named LIBCXX_HAS_WIN32_THREAD_API from libc++. Instead of using autodetection it will force the use of win32 threads instead of pthreads in headers included from libc++.
+
+Without this patch, libc++abi may depend on pthreads if present on the users build environment, even if win32 threading was selected for libc++.
+
+Differential revision: https://reviews.llvm.org/D98021
+---
+ libcxxabi/CMakeLists.txt | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/libcxxabi/CMakeLists.txt b/libcxxabi/CMakeLists.txt
+index b803347c2a8e3..8b0c88689df32 100644
+--- a/libcxxabi/CMakeLists.txt
++++ b/libcxxabi/CMakeLists.txt
+@@ -89,6 +89,7 @@ option(LIBCXXABI_ENABLE_STATIC_UNWINDER "Statically link the LLVM unwinder." OFF
+ option(LIBCXXABI_USE_COMPILER_RT "Use compiler-rt instead of libgcc" OFF)
+ option(LIBCXXABI_ENABLE_THREADS "Build with threads enabled" ON)
+ option(LIBCXXABI_HAS_PTHREAD_API "Ignore auto-detection and force use of pthread API" OFF)
++option(LIBCXXABI_HAS_WIN32_THREAD_API "Ignore auto-detection and force use of win32 thread API" OFF)
+ option(LIBCXXABI_HAS_EXTERNAL_THREAD_API
+   "Build libc++abi with an externalized threading API.
+   This option may only be set to ON when LIBCXXABI_ENABLE_THREADS=ON." OFF)
+@@ -374,6 +375,11 @@ if (NOT LIBCXXABI_ENABLE_THREADS)
+                         " be set to ON when LIBCXXABI_ENABLE_THREADS"
+                         " is also set to ON.")
+   endif()
++  if (LIBCXXABI_HAS_WIN32_THREAD_API)
++    message(FATAL_ERROR "LIBCXXABI_HAS_WIN32_THREAD_API can only"
++                        " be set to ON when LIBCXXABI_ENABLE_THREADS"
++                        " is also set to ON.")
++  endif()
+   if (LIBCXXABI_HAS_EXTERNAL_THREAD_API)
+     message(FATAL_ERROR "LIBCXXABI_HAS_EXTERNAL_THREAD_API can only"
+                         " be set to ON when LIBCXXABI_ENABLE_THREADS"
+@@ -394,6 +400,11 @@ if (LIBCXXABI_HAS_EXTERNAL_THREAD_API)
+                         " and LIBCXXABI_HAS_PTHREAD_API cannot be both"
+                         " set to ON at the same time.")
+   endif()
++  if (LIBCXXABI_HAS_WIN32_THREAD_API)
++    message(FATAL_ERROR "The options LIBCXXABI_HAS_EXTERNAL_THREAD_API"
++                        " and LIBCXXABI_HAS_WIN32_THREAD_API cannot be both"
++                        " set to ON at the same time.")
++  endif()
+   if (LIBCXXABI_BUILD_EXTERNAL_THREAD_LIBRARY)
+     message(FATAL_ERROR "The options LIBCXXABI_BUILD_EXTERNAL_THREAD_LIBRARY"
+                         " and LIBCXXABI_HAS_EXTERNAL_THREAD_API cannot be both"
+@@ -401,6 +412,14 @@ if (LIBCXXABI_HAS_EXTERNAL_THREAD_API)
+   endif()
+ endif()
+ 
++if (LIBCXXABI_HAS_PTHREAD_API)
++  if (LIBCXXABI_HAS_WIN32_THREAD_API)
++    message(FATAL_ERROR "The options LIBCXXABI_HAS_PTHREAD_API"
++            "and LIBCXXABI_HAS_WIN32_THREAD_API cannot be both"
++            "set to ON at the same time.")
++  endif()
++endif()
++
+ if (LLVM_ENABLE_MODULES)
+   # Ignore that the rest of the modules flags are now unused.
+   add_compile_flags_if_supported(-Wno-unused-command-line-argument)
+@@ -428,6 +447,10 @@ if (LIBCXXABI_HAS_PTHREAD_API)
+   add_definitions(-D_LIBCPP_HAS_THREAD_API_PTHREAD)
+ endif()
+ 
++if (LIBCXXABI_HAS_WIN32_THREAD_API)
++  add_definitions(-D_LIBCPP_HAS_THREAD_API_WIN32)
++endif()
++
+ if (LIBCXXABI_HAS_EXTERNAL_THREAD_API)
+   add_definitions(-D_LIBCPP_HAS_THREAD_API_EXTERNAL)
+ endif()

--- a/.orchestra/support/remove-files-from-other-component.sh
+++ b/.orchestra/support/remove-files-from-other-component.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+if [[ $# != 2 ]]; then
+    echo "Usage: $0 <component> <root>"
+    echo "Removes the files installed by <component>, relative to <root> path"
+    exit 1
+fi
+
+if [[ ! -d "$2" ]]; then
+    echo "Root '$2' does not exist or is not a directory"
+    exit 1
+fi
+
+orchestra inspect component installed-files "$1" | while read f; do
+    rm -f "$2/$f";
+done


### PR DESCRIPTION
This PR adds/fixes Windows builds for:

- llvm
- mingw
- gcc

It also switches the libcs from having a special `@headers` build to depending on a separate component for the headers (this was required by mingw which had to be installed in three phases).

**Note**: requires features from orchestra PR https://github.com/revng/revng-orchestra/pull/25