### PR TITLE
Multiple fixes to the CI scripts

### DIFF
--- a/.orchestra/ci/ci-run.sh
+++ b/.orchestra/ci/ci-run.sh
@@ -250,7 +250,18 @@ if test "$PUSH_CHANGES" = 1; then
         git add .
 
         if ! git diff --cached --quiet; then
-            git commit -m'Automatic binary archives'
+            set +x
+            COMMIT_MSG=$(cat <<EOF
+Automatic binary archives
+
+ORCHESTRA_CONFIG_COMMIT=$(git -C "$ORCHESTRA_ROOT" rev-parse --short HEAD || true)
+ORCHESTRA_CONFIG_BRANCH=$(git -C "$ORCHESTRA_ROOT" name-rev --name-only HEAD || true)
+COMPONENT_TARGET_BRANCH=$COMPONENT_TARGET_BRANCH
+EOF
+)
+            set -x
+
+            git commit -m "$COMMIT_MSG"
             git status
             git stash
             GIT_LFS_SKIP_SMUDGE=1 git fetch

--- a/.orchestra/ci/ci.sh
+++ b/.orchestra/ci/ci.sh
@@ -45,8 +45,15 @@ if [[ -n "$PUSHED_REF" ]]; then
     fi
 fi
 
-# Switch orchestra to the target branch or try the default list
 ogit fetch
+
+# If the target branch is not part of the default list and it does not already
+# exist, create it
+if [[ ! "$COMPONENT_TARGET_BRANCH" =~ ^(next-)?(develop|master)$ ]]; then
+    ogit branch -b "$COMPONENT_TARGET_BRANCH" master
+fi
+
+# Switch orchestra to the target branch or try the default list
 for B in "$COMPONENT_TARGET_BRANCH" next-develop develop next-master master; do
     if ogit checkout "$B"; then
         ORCHESTRA_TARGET_BRANCH="$B"


### PR DESCRIPTION
This PR addresses two bugs:

- a stream redirection mistyped as `>&` when it should have been `&>`
- symlinks for binary archives were updated incorrectly in some occasions

Also, it adds some useful information to the commit message that adds the new binary archives.

For more info about the issues refer to the commit messages, especially for the one related to the incorrect symlinks behaviour.