### PR TITLE
Update to llvm-12 and C++20

### DIFF
--- a/.orchestra/config/components/clang_release.yml
+++ b/.orchestra/config/components/clang_release.yml
@@ -18,6 +18,7 @@
 license: source/llvm/LICENSE.TXT
 configure: |
   extract.sh --into "$BUILD_DIR/source" "(@= source_url @)"
+  patch-if-exists "${ORCHESTRA_DOTDIR}/patches/clang-release-12.0.0-elf2yaml-wrong-comparisons.patch" "$BUILD_DIR/source"
   sed -i 's|GIT_FOUND|FALSE|g' "$BUILD_DIR/source/llvm/cmake/modules/VersionFromVCS.cmake"
   (@= configure_llvm(cmake_build_type="Release", cflags=" ", additional_cmake_options=cmake_opts(), source_dir="$BUILD_DIR/source") @)
 install: |

--- a/.orchestra/config/components/clang_release.yml
+++ b/.orchestra/config/components/clang_release.yml
@@ -8,6 +8,7 @@
 #@ def cmake_opts():
 - -DLLVM_ENABLE_PROJECTS="clang;compiler-rt;libcxxabi;libcxx;clang-tools-extra"
 - -DBUILD_SHARED_LIBS=OFF
+- -DLLVM_ENABLE_ZLIB=OFF
 #@ end
 
 #@yaml/text-templated-strings

--- a/.orchestra/config/components/llvm_common.lib.yml
+++ b/.orchestra/config/components/llvm_common.lib.yml
@@ -23,6 +23,7 @@
     -DLLVM_ENABLE_DUMP=ON \
     -DLLVM_ENABLE_TERMINFO=OFF \
     -DLIBCXX_ENABLE_ABI_LINKER_SCRIPT=OFF \
+    -DCMAKE_CXX_STANDARD=20 \
     -DLLVM_ENABLE_Z3_SOLVER=OFF \
     -DLLVM_INCLUDE_GO_TESTS=OFF \
     (@= expand_args(additional_cmake_options) @) \

--- a/.orchestra/config/components/ui/mesa.yml
+++ b/.orchestra/config/components/ui/mesa.yml
@@ -2,7 +2,7 @@
 #@ load("@ytt:overlay", "overlay")
 #@ load("/lib/create_component.lib.yml", "single_build_component")
 
-#@ source_url = "https://mesa.freedesktop.org/archive/mesa-20.1.2.tar.xz"
+#@ source_url = "https://mesa.freedesktop.org/archive/mesa-20.1.7.tar.xz"
 
 #@yaml/text-templated-strings
 ---

--- a/.orchestra/config/global_options.yml
+++ b/.orchestra/config/global_options.yml
@@ -11,7 +11,7 @@
 #! invalidate binary archives and require recompiling
 #! a large number of components
 
-#@ clang_release_version = "10.0.0"
+#@ clang_release_version = "12.0.0"
 #@ gcc_host_version = "10.1.0"
 
 #@data/values

--- a/.orchestra/patches/clang-release-12.0.0-elf2yaml-wrong-comparisons.patch
+++ b/.orchestra/patches/clang-release-12.0.0-elf2yaml-wrong-comparisons.patch
@@ -1,0 +1,22 @@
+diff --git a/llvm/tools/obj2yaml/elf2yaml.cpp b/llvm/tools/obj2yaml/elf2yaml.cpp
+index c85e2653b655..c0625be1131e 100644
+--- a/llvm/tools/obj2yaml/elf2yaml.cpp
++++ b/llvm/tools/obj2yaml/elf2yaml.cpp
+@@ -200,7 +200,7 @@ bool ELFDumper<ELFT>::shouldPrintSection(const ELFYAML::Section &S,
+     if (const ELFYAML::RawContentSection *RawSec =
+             dyn_cast<const ELFYAML::RawContentSection>(&S)) {
+       if (RawSec->Type != ELF::SHT_PROGBITS || RawSec->Link || RawSec->Info ||
+-          RawSec->AddressAlign != 1 || RawSec->Address || RawSec->EntSize)
++          (RawSec->AddressAlign != (yaml::Hex64)1) || RawSec->Address || RawSec->EntSize)
+         return true;
+ 
+       ELFYAML::ELF_SHF ShFlags = RawSec->Flags.getValueOr(ELFYAML::ELF_SHF(0));
+@@ -208,7 +208,7 @@ bool ELFDumper<ELFT>::shouldPrintSection(const ELFYAML::Section &S,
+       if (SecName == "debug_str")
+         return ShFlags != ELFYAML::ELF_SHF(ELF::SHF_MERGE | ELF::SHF_STRINGS);
+ 
+-      return ShFlags != 0;
++      return ShFlags != ELFYAML::ELF_SHF(0);
+     }
+   }
+ 


### PR DESCRIPTION
With this patchset, all the llvm-related tools in orchestra are bumped to llvm-12 and built as C++20.
This includes `clang-release` and `llvm`.