### PR TITLE
Update gitignore and set minimum orchestra version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,6 @@ sources
 .orchestra/tmproot
 .orchestra/binary-archives/*
 .orchestra/source_archives
-.orchestra/installed_components
-.orchestra/config_cache.yml
-.orchestra/config_cache.json
-.orchestra/remote_refs_cache.json
+.orchestra/cache
 .orchestra/config/user_*.yml
 .idea

--- a/.orchestra/ci/ci.sh
+++ b/.orchestra/ci/ci.sh
@@ -2,15 +2,9 @@
 
 # rev.ng CI entrypoint script
 # This script checks out the correct configuration branch and initializes
-# variables for the actual CI script (ci-run.sh)
-#
-# Parameters are supplied as environment variables.
-#
-# Optional parameters:
-#
-# PUSHED_REF:
-#   orchestra config commit/branch to use.
-#   Normally set by Gitlab or whoever triggers the CI.
+# variables, then it runs the appropriate script for the given CI stage
+# Parameters:
+#  $1 - CI stage: [build|post-build]
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ORCHESTRA_DIR="$DIR/../.."
@@ -37,6 +31,11 @@ function log_err() {
 }
 
 set -e
+
+if ! [[ "$1" =~ ^(post-)?build$ ]]; then
+    log_err "The first parameter of ci.sh must be 'build' or 'post-build'!"
+    exit 1
+fi
 
 # Determine target branch
 #
@@ -87,4 +86,8 @@ export COMPONENT_TARGET_BRANCH
 
 # Run "true" CI script
 log "Starting ci-run with COMPONENT_TARGET_BRANCH=$COMPONENT_TARGET_BRANCH"
-"$DIR/ci-run.sh"
+if [[ "$1" == "build" ]]; then
+    "$DIR/ci-run.sh"
+else
+    "$DIR/post-build.sh"
+fi

--- a/.orchestra/config/components.yml
+++ b/.orchestra/config/components.yml
@@ -28,6 +28,7 @@ environment:
   - "-C_INCLUDE_PATH": ""
   - "-CPLUS_INCLUDE_PATH": ""
   - "-OBJC_INCLUDE_PATH": ""
+min_orchestra_version: "3.2.0"
 
 paths: #@ datavalue("paths", default={})
 remote_base_urls: #@ datavalue("remote_base_urls")


### PR DESCRIPTION
This PR updates `.gitignore` and sets the minimum required orchestra version to 3.2.0 according to https://github.com/revng/revng-orchestra/pull/30