### PR TITLE
Improve CI debuggability

### DIFF
--- a/.orchestra/ci/ci-run.sh
+++ b/.orchestra/ci/ci-run.sh
@@ -32,23 +32,36 @@
 # BUILD_ALL_FROM_SOURCE: if == 1 do not use binary archives and build everything
 
 set -e
-set -x
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ORCHESTRA_ROOT="$(realpath "$DIR/../..")"
 ORCHESTRA_DOTDIR="$ORCHESTRA_ROOT/.orchestra"
 USER_OPTIONS="$ORCHESTRA_DOTDIR/config/user_options.yml"
 
+BOLD="\e[1m"
+RED="\e[31m"
+RESET="\e[0m"
+
 function log() {
-    echo "$1" > /dev/stderr
+    echo -en "${BOLD}" > /dev/stderr
+    echo -n '[+]' "$1" > /dev/stderr
+    echo -e "${RESET}" > /dev/stderr
+}
+
+function log_err() {
+    echo -en "${BOLD}${RED}" > /dev/stderr
+    echo -n '[!]' "$1" > /dev/stderr
+    echo -e "${RESET}" > /dev/stderr
 }
 
 PUSH_BINARY_ARCHIVE_EMAIL="${PUSH_BINARY_ARCHIVE_EMAIL:-sysadmin@rev.ng}"
 PUSH_BINARY_ARCHIVE_NAME="${PUSH_BINARY_ARCHIVE_NAME:-rev.ng CI}"
 
 if [[ "$BUILD_ALL_FROM_SOURCE" == 1 ]]; then
+    log "Build mode: building all components from source"
     BUILD_MODE="-B"
 else
+    log "Build mode: binary archives enabled"
     BUILD_MODE="-b"
 fi
 
@@ -60,7 +73,6 @@ cd "$DIR"
 #
 # Register deploy key, if any
 #
-set +x
 if test -n "$SSH_PRIVATE_KEY"; then
     eval "$(ssh-agent -s)"
     echo "$SSH_PRIVATE_KEY" | tr -d '\r' | ssh-add -
@@ -82,7 +94,6 @@ EOF
         git -C "$ORCHESTRA_ROOT" remote set-url origin "$ORCHESTRA_CONFIG_REPO_SSH_URL"
     fi
 fi
-set -x
 
 #
 # Install orchestra
@@ -107,7 +118,7 @@ which orc
 # Prepare the user_options.yml file
 #
 if test -e "$USER_OPTIONS"; then
-    log "$USER_OPTIONS already exists!"
+    log_err "$USER_OPTIONS already exists!"
     exit 1
 fi
 
@@ -123,13 +134,14 @@ if test -n "$TARGET_COMPONENTS_URL"; then
                          | grep '^Component' \
                          | cut -d' ' -f2)"
         if test -z "$NEW_COMPONENT"; then
-            log "Warning: ignoring URL $TARGET_COMPONENT_URL since it doesn't "\
-                "match any component"
+            log "Warning: ignoring URL $TARGET_COMPONENT_URL since it doesn't match any component"
         else
             TARGET_COMPONENTS="$NEW_COMPONENT $TARGET_COMPONENTS"
         fi
     done
 fi
+
+log "Target components: $TARGET_COMPONENTS"
 
 if test -z "$TARGET_COMPONENTS"; then
     log "Nothing to do!"
@@ -168,22 +180,23 @@ cat >> "$USER_OPTIONS" <<EOF
 EOF
 
 # Print debug information
+log "User options:"
 cat "$USER_OPTIONS"
-find ..
 
 orc update --no-config
 
 # Print debugging information
-# Full dependency graph
+log "Complete dependency graph"
 orc graph "$BUILD_MODE"
-# Solved dependency graph for the target component
-orc graph --solved "$BUILD_MODE" "$TARGET_COMPONENT"
-# Information about the components
-orc components --hashes --deps
-# Binary archives commit
+for TARGET_COMPONENT in $TARGET_COMPONENTS; do
+    log "Solved dependency graph for the target component $TARGET_COMPONENT"
+    orc graph --solved "$BUILD_MODE" "$TARGET_COMPONENT"
+done
+log "Information about the components"
+orc components --hashes
+log "Binary archives commit"
 for BINARY_ARCHIVE_PATH in $(orc ls --binary-archives); do
-    echo "Commit for $BINARY_ARCHIVE_PATH: "\
-           "$(git -C "$BINARY_ARCHIVE_PATH" rev-parse HEAD)"
+    log "Commit for $BINARY_ARCHIVE_PATH: $(git -C "$BINARY_ARCHIVE_PATH" rev-parse HEAD)"
 done
 
 #
@@ -191,6 +204,7 @@ done
 #
 RESULT=0
 for TARGET_COMPONENT in $TARGET_COMPONENTS; do
+    log "Building target component $TARGET_COMPONENT"
     if ! orc --quiet install "$BUILD_MODE" --test --create-binary-archives "$TARGET_COMPONENT"; then
         RESULT=1
         break
@@ -233,7 +247,7 @@ if [[ "$PROMOTE_BRANCHES" = 1 ]] || [[ "$PUSH_CHANGES" = 1 ]]; then
         orc fix-binary-archives-symlinks
     fi
 else
-    echo "Skipping branch promotion (\$PROMOTE_BRANCHES = '$PROMOTE_BRANCHES', \$PUSH_CHANGES = '$PUSH_CHANGES')"
+    log "Skipping branch promotion (PROMOTE_BRANCHES='$PROMOTE_BRANCHES', PUSH_CHANGES='$PUSH_CHANGES')"
 fi
 
 if [[ "$PUSH_BINARY_ARCHIVES" = 1 ]] || [[ "$PUSH_CHANGES" = 1 ]]; then
@@ -290,7 +304,7 @@ COMPONENT_TARGET_BRANCH=$COMPONENT_TARGET_BRANCH"
 
     done
 else
-    echo "Skipping binary archives push (\$PUSH_BINARY_ARCHIVES = '$PUSH_BINARY_ARCHIVES', \$PUSH_CHANGES = '$PUSH_CHANGES')"
+    log "Skipping binary archives push (PUSH_BINARY_ARCHIVES='$PUSH_BINARY_ARCHIVES', PUSH_CHANGES='$PUSH_CHANGES')"
 fi
 
 exit "$RESULT"

--- a/.orchestra/ci/ci-run.sh
+++ b/.orchestra/ci/ci-run.sh
@@ -216,15 +216,10 @@ if [[ "$PROMOTE_BRANCHES" = 1 ]] || [[ "$PUSH_CHANGES" = 1 ]]; then
     # Promote `next-*` branches to `*`
     #
     if test "$RESULT" -eq 0; then
-
         # Clone all the components having branch next-*
-        for COMPONENT in $(orc components --branch 'next-*' \
-                | grep '^Component' \
-                | awk '{ print $2 }'); do
-            # TODO: find a more robust way to clone if not already cloned
-            if ! test -d "$ORCHESTRA_ROOT/sources/$COMPONENT"; then
-                orc clone "$COMPONENT"
-            fi
+        for COMPONENT in $(orc components --json --branch 'next-*' | jq -r ".[].name"); do
+            log "Cloning $COMPONENT"
+            orc clone --no-force "$COMPONENT"
         done
 
         # Promote next-* to *.

--- a/.orchestra/ci/ci-run.sh
+++ b/.orchestra/ci/ci-run.sh
@@ -211,6 +211,9 @@ for TARGET_COMPONENT in $TARGET_COMPONENTS; do
     fi
 done
 
+log "Components JSON dump"
+orc components --json
+
 if [[ "$PROMOTE_BRANCHES" = 1 ]] || [[ "$PUSH_CHANGES" = 1 ]]; then
     #
     # Promote `next-*` branches to `*`

--- a/.orchestra/ci/ci-run.sh
+++ b/.orchestra/ci/ci-run.sh
@@ -102,17 +102,17 @@ if test -n "$REVNG_ORCHESTRA_URL"; then
     # COMPONENT_TARGET_BRANCH is not quoted on purpose -- if empty it has to be ignored instead of being expanded to
     # and empty string
     for REVNG_ORCHESTRA_TARGET_BRANCH in $COMPONENT_TARGET_BRANCH next-develop develop next-master master; do
-        if pip3 install --user "$REVNG_ORCHESTRA_URL@$REVNG_ORCHESTRA_TARGET_BRANCH"; then
+        if pip3 -q install --user "$REVNG_ORCHESTRA_URL@$REVNG_ORCHESTRA_TARGET_BRANCH"; then
             break
         fi
     done
 else
-    pip3 install --user revng-orchestra
+    pip3 -q install --user revng-orchestra
 fi
 
 # Make sure we can run orchestra
 export PATH="$HOME/.local/bin:$PATH"
-which orc
+which orc >/dev/null
 
 #
 # Prepare the user_options.yml file

--- a/.orchestra/ci/ci.sh
+++ b/.orchestra/ci/ci.sh
@@ -61,7 +61,8 @@ ogit fetch
 
 # If the target branch is not part of the default list and it does not already
 # exist, create it
-if [[ ! "$COMPONENT_TARGET_BRANCH" =~ ^(next-)?(develop|master)$ ]]; then
+if [[ ! "$COMPONENT_TARGET_BRANCH" =~ ^(next-)?(develop|master)$ ]] && \
+    ! git rev-parse --quiet --verify "$COMPONENT_TARGET_BRANCH" >/dev/null ; then
     log "Creating branch $COMPONENT_TARGET_BRANCH for orchestra configuration from master"
     ogit checkout -b "$COMPONENT_TARGET_BRANCH" master
 fi

--- a/.orchestra/ci/ci.sh
+++ b/.orchestra/ci/ci.sh
@@ -15,17 +15,28 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ORCHESTRA_DIR="$DIR/../.."
 
+BOLD="\e[1m"
+RED="\e[31m"
+RESET="\e[0m"
+
 # Runs git in the orchestra directory
 function ogit () {
     git -C "$ORCHESTRA_DIR" "$@"
 }
 
 function log() {
-    echo "$1" > /dev/stderr
+    echo -en "${BOLD}" > /dev/stderr
+    echo -n '[+]' "$1" > /dev/stderr
+    echo -e "${RESET}" > /dev/stderr
+}
+
+function log_err() {
+    echo -en "${BOLD}${RED}" > /dev/stderr
+    echo -n '[!]' "$1" > /dev/stderr
+    echo -e "${RESET}" > /dev/stderr
 }
 
 set -e
-set -x
 
 # Determine target branch
 #
@@ -37,10 +48,11 @@ set -x
 COMPONENT_TARGET_BRANCH=""
 
 if [[ -n "$PUSHED_REF" ]]; then
+    log "PUSHED_REF=$PUSHED_REF"
     if [[ "$PUSHED_REF" = refs/heads/* ]]; then
         COMPONENT_TARGET_BRANCH="${PUSHED_REF#refs/heads/}"
     else
-        log "PUSHED_REF ($PUSHED_REF) is not a branch, bailing out"
+        log_err "PUSHED_REF ($PUSHED_REF) is not a branch, bailing out"
         exit 0
     fi
 fi
@@ -50,6 +62,7 @@ ogit fetch
 # If the target branch is not part of the default list and it does not already
 # exist, create it
 if [[ ! "$COMPONENT_TARGET_BRANCH" =~ ^(next-)?(develop|master)$ ]]; then
+    log "Creating branch $COMPONENT_TARGET_BRANCH for orchestra configuration from master"
     ogit checkout -b "$COMPONENT_TARGET_BRANCH" master
 fi
 
@@ -62,15 +75,15 @@ for B in "$COMPONENT_TARGET_BRANCH" next-develop develop next-master master; do
 done
 
 if [[ -z "$ORCHESTRA_TARGET_BRANCH" ]]; then
-    echo "[!] All checkout attempts failed, aborting"
+    log_err "All checkout attempts failed, aborting"
     exit 1
 fi
 
 ORCHESTRA_CONFIG_COMMIT="$(ogit rev-parse --short "$ORCHESTRA_TARGET_BRANCH")"
-echo "[+] Using configuration branch $ORCHESTRA_TARGET_BRANCH "\
-     "(commit $ORCHESTRA_CONFIG_COMMIT)"
+log "Using configuration branch $ORCHESTRA_TARGET_BRANCH (commit $ORCHESTRA_CONFIG_COMMIT)"
 
 export COMPONENT_TARGET_BRANCH
 
 # Run "true" CI script
+log "Starting ci-run with COMPONENT_TARGET_BRANCH=$COMPONENT_TARGET_BRANCH"
 "$DIR/ci-run.sh"

--- a/.orchestra/ci/install-dependencies.sh
+++ b/.orchestra/ci/install-dependencies.sh
@@ -4,9 +4,9 @@ set -e
 
 export DEBIAN_FRONTEND=noninteractive
 
-apt-get update
+apt-get -qq update
 
-apt-get install --no-install-recommends --yes \
+apt-get -qq install --no-install-recommends --yes \
   aufs-tools \
   autoconf \
   automake \
@@ -47,7 +47,7 @@ apt-get install --no-install-recommends --yes \
   zlib1g-dev
 
 # Dependencies for Qt
-apt install --no-install-recommends --yes \
+apt-get -qq install --no-install-recommends --yes \
   gperf \
   libcap-dev \
   libfontconfig1-dev \
@@ -69,9 +69,9 @@ apt install --no-install-recommends --yes \
   libxkbcommon-x11-dev \
   libxrender-dev
 
-pip3 install --user --upgrade setuptools wheel mako meson==0.56.2 pyelftools pygraphviz==1.6
+pip3 -q install --user --upgrade setuptools wheel mako meson==0.56.2 pyelftools pygraphviz==1.6
 
 if ! which git-lfs &> /dev/null; then
   curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
-  apt-get install --no-install-recommends --yes git-lfs
+  apt-get -qq install --no-install-recommends --yes git-lfs
 fi

--- a/.orchestra/ci/install-dependencies.sh
+++ b/.orchestra/ci/install-dependencies.sh
@@ -22,6 +22,7 @@ apt-get -qq install --no-install-recommends --yes \
   git \
   graphviz \
   graphviz-dev \
+  jq \
   libc-dev \
   libexpat1-dev \
   libglib2.0-dev \


### PR DESCRIPTION
This PR is needed to debug a build failure on `ui/mesa`. 
It also generally improves the CI script debuggability, reducing verbosity where not needed and printing more useful info.
The last commit (4a0c9fd93ac1834e47827fa3ce43a06f9390d094) is only there for debugging purposes (runs `orc components --json` after `orc install` because we're interested in seeing which commits orchestra is using after it failed).