### PR TITLE
Fix config branch creation

### DIFF
--- a/.orchestra/ci/ci.sh
+++ b/.orchestra/ci/ci.sh
@@ -50,7 +50,7 @@ ogit fetch
 # If the target branch is not part of the default list and it does not already
 # exist, create it
 if [[ ! "$COMPONENT_TARGET_BRANCH" =~ ^(next-)?(develop|master)$ ]]; then
-    ogit checkout -b "$COMPONENT_TARGET_BRANCH" master
+    ogit checkout "$COMPONENT_TARGET_BRANCH" || ogit checkout -b "$COMPONENT_TARGET_BRANCH" master
 fi
 
 # Switch orchestra to the target branch or try the default list


### PR DESCRIPTION
Fixes a bug in the CI script which caused the creation of the branch for the orchestra config with HEAD pointing to `master` instead of the HEAD for the same branch present in the `origin` remote.