### PR TITLE
llvm-documentation: enable figures in SVG

### DIFF
--- a/.orchestra/config/components/llvm_documentation.yml
+++ b/.orchestra/config/components/llvm_documentation.yml
@@ -25,6 +25,7 @@ builds:
         -DCMAKE_BUILD_TYPE="Debug" \
         -DLLVM_BUILD_DOCS=ON \
         -DLLVM_ENABLE_DOXYGEN=ON \
+        -DLLVM_DOXYGEN_SVG=ON \
         -DLLVM_TARGETS_TO_BUILD="X86" \
         -DBUILD_SHARED_LIBS=ON \
         -DLLVM_ENABLE_PROJECTS="clang" \


### PR DESCRIPTION
SVGs figures are supported by default in `graphviz`, and they are strictly better than png, because they have searchable text in them.

Moreover, this fixes a subtle bug: if you try to build llvm-documentation in an orchestra environment where the `ui/graphviz` is installed, building the llvm-ducumentation will try to used that and fail because we ship `graphviz` and configuring it with `--without-libgd`, so the `dot` utility we install cannot emit png files.

SVG is builting in `graphviz`, so switching to SVG enables to successfully build llvm-documentation even on systems where `ui/graphviz` is installed.