### PR TITLE
Fix: pass Github SSH URL to TARGET_COMPONENTS_URL

### DIFF
--- a/.orchestra/ci/ci-hook/app.py
+++ b/.orchestra/ci/ci-hook/app.py
@@ -157,7 +157,7 @@ def github_hook():
     if headers.get("X-Github-Event", "") == "push":
         data = request.json
         trigger_ci(hub_to_lab(data["sender"]["login"]),
-                   data["repository"]["clone_url"],
+                   data["repository"]["clone_url"] + " " + data["project"]["ssh_url"],
                    data["ref"],
                    data["before"],
                    data["after"])


### PR DESCRIPTION
Pass the Github SSH URL to the list of URLs by which components are selected. Before this change the CI didn't always add the correct components to the list of components to build.