### PR TITLE
Log the components JSON for debugging

### DIFF
--- a/.orchestra/ci/ci-run.sh
+++ b/.orchestra/ci/ci-run.sh
@@ -190,6 +190,12 @@ for BINARY_ARCHIVE_PATH in $(orc ls --binary-archives); do
     log "Commit for $BINARY_ARCHIVE_PATH: $(git -C "$BINARY_ARCHIVE_PATH" rev-parse HEAD)"
 done
 
+# TODO: remove, added to debug the CI
+log "Components JSON"
+log "------------------------------------"
+orc components --json
+log "------------------------------------"
+
 #
 # Actually run the build
 #


### PR DESCRIPTION
Please merge this **in `feature/model-type-system`** for debugging purposes.
It adds a call to `orc components --json` to dump detailed info about the components, in particular the commit of `revng` which I suspect was wrong and caused revng not to be rebuilt. 