### PR TITLE
Add support for PNG in ui/graphviz with libgd

### DIFF
--- a/.orchestra/config/components/ui/graphviz.yml
+++ b/.orchestra/config/components/ui/graphviz.yml
@@ -33,7 +33,6 @@ configure: |
     --without-fontconfig \
     --without-freetype2 \
     --without-ipsepcola \
-    --without-libgd \
     --with-sfdp \
     --without-ming \
     --with-cgraph \


### PR DESCRIPTION
PNG figures are not supported by default in `graphviz` if `libgd` is not configured, but `llvm-documentation` builds PNG figures by default.

Hence, before this commit, if `llvm-documentation` was built in an `orchestra` environment where the `ui/graphviz` was installed, building the `llvm-ducumentation` would fail and just emit .dot files instead, breaking the visualization of the figures in the doc.

This commit enables `libgd` in `ui/graphviz`, providing support for PNGs. This fixes the problem described above, always enabling the `dot` utility to emit PNGs, like llvm does.

Another fix would have been to configure `llvm-documentation` to emit SVG figures, that are always supported by `graphviz`.
However, this solution is not viable because SVGs cannot be visualized properly by Zeal.
According to the information we have now, Zeal only supports PNGs among the output formats of the `dot` utility, so the only viable solution is to enable `dot` to emit PNGs, to make Zeal happy.