### PR TITLE
Add missing libc dependency to coreutils

### DIFF
--- a/.orchestra/config/components/toolchain/lib/coreutils.lib.yml
+++ b/.orchestra/config/components/toolchain/lib/coreutils.lib.yml
@@ -1,13 +1,43 @@
-#@ load("/lib/fn_args.lib.yml", "mandatory")
-#@ load("/lib/make.lib.yml", "make")
+#@ load("@ytt:template", "template")
 
+#@ load("/lib/make.lib.yml", "make")
 #@ load("/lib/optimization_flavors.lib.yml", "libc_optimization_flavors")
 
 #@yaml/text-templated-strings
 ---
-#@ def coreutils_build(triple=mandatory, coreutils_version=mandatory, additional_cflags="", additional_ldflags=""):
+#@ def libc_dependencies(
+#@     *,
+#@     toolchain_name,
+#@     mingw64_version,
+#@     musl_version,
+#@     uclibc_version
+#@   ):
 
-#@   source_url = "https://ftp.gnu.org/gnu/coreutils/coreutils-" + coreutils_version + ".tar.xz"
+#@ if/end mingw64_version:
+- toolchain/(@= toolchain_name @)/mingw64
+
+#@ if/end musl_version:
+- toolchain/(@= toolchain_name @)/musl
+
+#@ if/end uclibc_version:
+- toolchain/(@= toolchain_name @)/uclibc
+
+#@ end
+
+#@yaml/text-templated-strings
+---
+#@ def coreutils_build(
+#@     *,
+#@     triple,
+#@     toolchain_name,
+#@     coreutils_version,
+#@     mingw64_version,
+#@     musl_version,
+#@     uclibc_version,
+#@     additional_cflags="",
+#@     additional_ldflags=""
+#@   ):
+#@ source_url = "https://ftp.gnu.org/gnu/coreutils/coreutils-" + coreutils_version + ".tar.xz"
 configure: |
   mkdir -p "$BUILD_DIR"
 
@@ -34,16 +64,26 @@ install: |
   cd "$BUILD_DIR"
   (@= make @)
   (@= make @) install
+dependencies:
+  - #@ template.replace(libc_dependencies(toolchain_name=toolchain_name, mingw64_version=mingw64_version, musl_version=musl_version, uclibc_version=uclibc_version))
 #@ end
 
 #@yaml/text-templated-strings
 ---
-#@ def create_coreutils_component(triple=mandatory, coreutils_version=mandatory):
+#@ def create_coreutils_component(
+#@     *,
+#@     triple,
+#@     toolchain_name,
+#@     coreutils_version,
+#@     mingw64_version,
+#@     musl_version,
+#@     uclibc_version
+#@   ):
 license: COPYING
 default_build: default_static
 builds:
   #@ for flavor, flags in libc_optimization_flavors.items():
-  (@= flavor @)_static: #@ coreutils_build(triple=triple, coreutils_version=coreutils_version, additional_cflags=flags, additional_ldflags="-static")
-  (@= flavor @): #@ coreutils_build(triple=triple, coreutils_version=coreutils_version, additional_cflags=flags)
+  (@= flavor @)_static: #@ coreutils_build(triple=triple, toolchain_name=toolchain_name, coreutils_version=coreutils_version, mingw64_version=mingw64_version, musl_version=musl_version, uclibc_version=uclibc_version, additional_cflags=flags, additional_ldflags="-static")
+  (@= flavor @): #@ coreutils_build(triple=triple, toolchain_name=toolchain_name, coreutils_version=coreutils_version, mingw64_version=mingw64_version, musl_version=musl_version, uclibc_version=uclibc_version, additional_cflags=flags)
   #@ end
 #@ end

--- a/.orchestra/config/components/toolchain/lib/toolchain.lib.yml
+++ b/.orchestra/config/components/toolchain/lib/toolchain.lib.yml
@@ -1,7 +1,5 @@
 #@ load("@ytt:template", "template")
 
-#@ load("/lib/fn_args.lib.yml", "mandatory")
-
 #@ load("/components/toolchain/lib/linux_headers.lib.yml", "create_linux_headers_component")
 #@ load("/components/toolchain/lib/binutils.lib.yml", "create_binutils_component")
 #@ load("/components/toolchain/lib/gdb.lib.yml", "create_gdb_component")
@@ -15,8 +13,9 @@
 #@yaml/text-templated-strings
 ---
 #@ def create_toolchain_components(
-#@    toolchain_name=mandatory,
-#@    triple=mandatory,
+#@    *,
+#@    toolchain_name,
+#@    triple,
 #@    linux_arch_name=None,
 #@    linux_version=None,
 #@    binutils_version=None,
@@ -33,7 +32,7 @@
 #@    extra_binutils_configure_options=None,
 #@    extra_gcc_make_variables="",
 #@    dynamic=None,
-#@    spec=False,
+#@    spec=False
 #@ ):
 
 #@ if/end binutils_version:
@@ -55,7 +54,7 @@
 (@= "toolchain/" + toolchain_name + "/musl" @): #@ create_musl_component(triple=triple, musl_version=musl_version, toolchain_name=toolchain_name, gcc_version=gcc_version)
 
 #@ if/end coreutils_version:
-(@= "toolchain/" + toolchain_name + "/coreutils" @): #@ create_coreutils_component(triple=triple, coreutils_version=coreutils_version)
+(@= "toolchain/" + toolchain_name + "/coreutils" @): #@ create_coreutils_component(triple=triple, toolchain_name=toolchain_name, coreutils_version=coreutils_version, mingw64_version=mingw64_version, musl_version=musl_version, uclibc_version=uclibc_version)
 
 #@ if/end uclibc_version:
 (@= "toolchain/" + toolchain_name + "/uclibc" @): #@ create_uclibc_component(triple=triple, toolchain_name=toolchain_name, uclibc_version=uclibc_version, uclibc_arch_name=uclibc_arch_name, gcc_version=gcc_version, binutils_version=binutils_version)


### PR DESCRIPTION
@antoniofrighetto reported a coreutils build failure at link time, due to coreutils missing a dependency on the correct platform libc.
Installing the correct libc solved the issue, so this PR does that.
Not yet tested, thus opening as draft.