### PR TITLE
Updates needed by revng/revng#97 (autogenerated model classes)

### DIFF
--- a/.orchestra/ci/ci.sh
+++ b/.orchestra/ci/ci.sh
@@ -88,6 +88,8 @@ log "Using configuration branch $ORCHESTRA_TARGET_BRANCH (commit $ORCHESTRA_CONF
 
 export COMPONENT_TARGET_BRANCH
 
+export REVNG_ENSURE_LATEST_SCHEMA=1
+
 # Run "true" CI script
 log "Starting ci-run with COMPONENT_TARGET_BRANCH=$COMPONENT_TARGET_BRANCH"
 "$DIR/ci-run.sh"

--- a/.orchestra/config/components.yml
+++ b/.orchestra/config/components.yml
@@ -14,7 +14,7 @@ environment:
   - PKG_CONFIG_PATH: $ORCHESTRA_ROOT/lib/pkgconfig:$ORCHESTRA_ROOT/share/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}
   - INSTALL_LINK_ONLY_PATH: $ORCHESTRA_ROOT/link-only
   - LIBGL_DRIVERS_PATH: $ORCHESTRA_ROOT/lib/dri${LIBGL_DRIVERS_PATH:+:${LIBGL_DRIVERS_PATH}}
-  - PYTHONPATH: $ORCHESTRA_ROOT/lib/python${PYTHONPATH:+:${PYTHONPATH}}
+  - PYTHONPATH: $ORCHESTRA_ROOT/python${PYTHONPATH:+:${PYTHONPATH}}
   - LIBRARY_PATH: /usr/lib/x86_64-linux-gnu
   - HARD_FLAGS_COMPILE: #@ str(datavalue("hard_flags_compile"))
   - HARD_FLAGS_CXX_CLANG: #@ str(datavalue("hard_flags_cxx_clang"))

--- a/.orchestra/config/components/llvmcpy.yml
+++ b/.orchestra/config/components/llvmcpy.yml
@@ -10,7 +10,7 @@ builds:
     configure: |
       mkdir -p "$BUILD_DIR"
     install: |
-      export PYTHONPATH="$DESTDIR/lib/python"
+      export PYTHONPATH="$DESTDIR/python"
       mkdir -p "$PYTHONPATH"
       cd "$SOURCE_DIR"
       python3 setup.py build --build-base "$SOURCE_DIR"

--- a/.orchestra/config/components/revng.yml
+++ b/.orchestra/config/components/revng.yml
@@ -1,10 +1,13 @@
 #@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:template", "template")
 #@ load("/lib/cmake.lib.yml", "cmake_boost_configuration", "typical_cmake_builds")
 
 ---
 #@ def build_args():
 test: true
-extra_cmake_args: #@ cmake_boost_configuration
+extra_cmake_args:
+  - #@ template.replace(cmake_boost_configuration)
+  - -DREVNG_ENSURE_LATEST_SCHEMA=${REVNG_ENSURE_LATEST_SCHEMA:-0}
 build_dependencies:
   - cmake
   - revng-qa


### PR DESCRIPTION
This PR supports PR https://github.com/revng/revng/pull/97

- updates PYTHONPATH
- supports setting the appropriate env var in the CI so that the latest committed schema is checked against the autogenerated one