### PR TITLE
Install Jinja2 in CI script

### DIFF
--- a/.orchestra/ci/install-dependencies.sh
+++ b/.orchestra/ci/install-dependencies.sh
@@ -74,7 +74,20 @@ apt-get -qq install --no-install-recommends --yes \
 # * lit version should always match clang-release and llvm version
 # * pydot is incompatible with recent versions of pyparsing:
 #   https://github.com/pydot/pydot/issues/277
-pip3 -q install --user --upgrade setuptools wheel mako meson==0.56.2 pyelftools lit==12.0.0 pyparsing==2.4.7 pydot grandiso
+PYTHON_DEPENDENCIES=(
+  setuptools
+  wheel
+  mako
+  meson==0.56.2
+  pyelftools
+  lit==12.0.0
+  pyparsing==2.4.7
+  pydot
+  grandiso
+  Jinja2
+)
+
+pip3 -q install --user --upgrade "${PYTHON_DEPENDENCIES[@]}"
 
 if ! which git-lfs &> /dev/null; then
   curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash


### PR DESCRIPTION
This PR adds Jinja2 among the packages installed by the CI script (used to expand templates by `tuple_tree_generator`, see
https://github.com/revng/revng/pull/109#discussion_r770729005)