### PR TITLE
More consistent whitespace trimming

### DIFF
--- a/.orchestra/config/components/toolchain/lib/mingw64.lib.yml
+++ b/.orchestra/config/components/toolchain/lib/mingw64.lib.yml
@@ -28,7 +28,7 @@ configure: |
   export CC="${NEW_GCC}"
   export CPPFLAGS="-I${ORCHESTRA_ROOT}/(@= triple @)/usr/include"
   export CHOST="(@= triple @)"
-  (@ end -@)
+  (@ end @)
   "$BUILD_DIR/configure" \
     --disable-silent-rules \
     --target=(@= triple @) \

--- a/.orchestra/config/lib/cmake.lib.yml
+++ b/.orchestra/config/lib/cmake.lib.yml
@@ -65,7 +65,7 @@
 (@= flavor @):
   configure: |
     (@- if pre_configure_script: @)
-    (@= pre_configure_script @)
+    (@-= pre_configure_script @)
     (@ end -@)
 
     (@- if source_url: @)
@@ -78,13 +78,14 @@
     (@= cmake @) \
       "$SOURCE_DIR" \
       -G"(@= build_system @)" \
-      (@= expand_args(cmdline_cmake_base_configuration(cmake_build_type=opts["cmake_build_type"], extra_compiler_flags=opts["extra_compiler_flags"])) @) \
+      (@= expand_args(cmdline_cmake_base_configuration(cmake_build_type=opts["cmake_build_type"], extra_compiler_flags=opts["extra_compiler_flags"])) @)
+      (@- if extra_cmake_args: @) \
       (@= expand_args(extra_cmake_args) @)
+      (@- end @)
 
     (@- if post_configure_script: @)
     (@= post_configure_script @)
-    (@ end -@)
-
+    (@ end @)
   install: |
     (@- if pre_install_script: @)
     (@= pre_install_script @)
@@ -98,14 +99,13 @@
       ctest --output-on-failure ${JOBS:+-j$JOBS}
       cd -
     fi
-    (@ end -@)
+    (@- end @)
 
     cmake --install "$BUILD_DIR"
 
     (@- if post_install_script: @)
     (@= post_install_script @)
-    (@ end -@)
-
+    (@ end @)
   #@ if/end dependencies:
   dependencies: #@ dependencies
 

--- a/.orchestra/config/lib/create_component.lib.yml
+++ b/.orchestra/config/lib/create_component.lib.yml
@@ -43,21 +43,21 @@ builds:
       (@- if pre_install: @)
       (@-= pre_install @)
       (@ end -@)
-      (@- if build_system == "make": @)
+      (@- if build_system == "make": -@)
       cd "$BUILD_DIR"
       (@= make @)
       (@= make @) install DESTDIR="$DESTDIR"
-      (@- elif build_system == "ninja": @)
+      (@- elif build_system == "ninja": -@)
       cd "$BUILD_DIR"
       (@= ninja @) install
       (@- elif install: @)
-      (@-= install -@)
+      (@-= install @)
       (@- else: @)
-      (@- fail("build_system must be either make or ninja or you must specify an install script") @)
-      (@- end -@)
+      (@ fail("build_system must be either make or ninja or you must specify an install script") @)
+      (@ end @)
       (@- if post_install: @)
-      (@= post_install -@)
-      (@- end -@)
+      (@= post_install @)
+      (@- end @)
 #@ if/end add_to_path:
 add_to_path: #@ add_to_path
 


### PR DESCRIPTION
I reviewed all instances of this regex: `\(@-|-@\)`.

This PR tries to apply whitespace trimming more consistently.

Blocks should use the following pattern where possible:

```
(@- startblock @)
somethingsomething
(@ endblock @)
```

The exception are blocks that start/end a string. Both should trim whitespace following the block closing tag, since we don't want spurious whitespace at the start or end of a string. Aside aesthetic reasons, it is also undesirable because it causes ytt to emit less well-known YAML "chomp indicators" (e.g. starting string literals with `|-` or `|+`, see https://www.yaml.info/learn/quote.html#chomp).
There are other corner cases; for instance, if multiple conditional blocks appear at the start of a string literal, all of them should trim the whitespace following their closing tag.

To review these changes I suggest diffing the config before/after applying this patch:

- `orc inspect config > /tmp/config_1.yml`
- `git switch feature/improve-whitespace-trimming`
- `orc inspect config > /tmp/config_2.yml`
- `diff /tmp/config_1.yml /tmp/config_2.yml`

I reviewed the changes and didn't see anything that should break the build.

Another positive side effect of this PR is that the configure script for some components (e.g. libfort) is now properly expanded instead of appearing as a literal string with escaped newlines.