### PR TITLE
llvm/clang-release: do not depend on ncurses

### DIFF
--- a/.orchestra/config/components/clang_release.yml
+++ b/.orchestra/config/components/clang_release.yml
@@ -44,7 +44,6 @@ dependencies:
   - gcc-host-toolchain
   - libunwind
   - zlib
-  - ncurses
 #@ end
 
 ---
@@ -115,7 +114,6 @@ dependencies:
   - gcc-host-toolchain
   - libunwind
   - zlib
-  - ncurses
 #@ end
 
 #@ end
@@ -224,7 +222,6 @@ dependencies:
   - gcc-host-toolchain
   - libunwind
   - zlib
-  - ncurses
 #@ end
 
 #@overlay/match by=overlay.all, expects=1

--- a/.orchestra/config/components/llvm.yml
+++ b/.orchestra/config/components/llvm.yml
@@ -59,7 +59,6 @@ builds:
         - host-libcxx
         - libunwind
         - zlib
-        - ncurses
         - lit
       #@ if/end ndebug == False:
       ndebug: false


### PR DESCRIPTION
When building clang/llvm we explicitly pass LLVM_ENABLE_TERMINFO=OFF, remove dependecy from clang-release and llvm.