### PR TITLE
revng-distributable: include calc-x86-64-static

### DIFF
--- a/.orchestra/config/components/revng_distributable.yml
+++ b/.orchestra/config/components/revng_distributable.yml
@@ -15,7 +15,7 @@ configure: |
   mkdir -p "$BUILD_DIR"
 install: |
   INSTALLER="$ORCHESTRA_DOTDIR/support/revng-distributable/install.sh"
-  echo "b8e725588909c45caaf808acfb201dd5c6fdcee42f69ac84508e91a44f22ad39 $INSTALLER" | \
+  echo "e58c33be17a6ee5a4e2157f56077efdb36c80d09f2570370e8ae2872ab4a713c $INSTALLER" | \
     sha256sum --quiet -c -
   "$INSTALLER" (@= " ".join(distributable_components()) @)
 build_dependencies:

--- a/.orchestra/support/revng-distributable/install.sh
+++ b/.orchestra/support/revng-distributable/install.sh
@@ -34,8 +34,7 @@ grep -vE \
   -e '^share/terminfo/' | \
 rsync \
   --archive \
-  --verbose \
-  --progress \
+  --quiet \
   --files-from=- \
   "$ORCHESTRA_ROOT/." \
   "${DESTDIR}${ORCHESTRA_ROOT}/revng/root/."
@@ -107,6 +106,10 @@ for IDX in share/orchestra/*.idx; do
 done
 rm "$TMP_IDX"
 
+# Copying x86_64-calc for smoke tests
+TEST_BINARY=$(echo "$ORCHESTRA_ROOT/share/revng/test/tests/runtime/calc-x86-64-static-revng-qa.compiled-stripped-"*)
+cp -a "$TEST_BINARY" share/revng/calc-x86-64-static
+
 echo "Generating checksums"
 cd "$DESTDIR/$ORCHESTRA_ROOT/revng"
 find root -type f -print0 | xargs -0 -P"$JOBS" -n100 sha256sum > checksums.sha256
@@ -118,7 +121,6 @@ find . -not -type d -not -path './revng/*' -delete
 find . -type d -empty -delete
 
 if [ "$RUN_TESTS" -eq 1 ]; then
-  TEST_BINARY=$(echo "$ORCHESTRA_ROOT/share/revng/test/tests/runtime/calc-x86-64-static-revng-qa.compiled-stripped-"*)
   # Orchestra adds quite a few environment variables, which we want to avoid to use when doing self-test
   # In order to launch self-test with as few environment variables as possible we:
   # * use `env -i` to start with no environment variables


### PR DESCRIPTION
Include the executable calc-x86-64-static in revng-distributable to allow downstream users to check that revng is working properly.