### PR TITLE
Add `python2` component

### DIFF
--- a/.orchestra/ci/install-system-dependencies.sh
+++ b/.orchestra/ci/install-system-dependencies.sh
@@ -66,11 +66,6 @@ PACKAGES+=(doxygen)
 PACKAGES+=(graphviz)
 
 #
-# qemu dependencies
-#
-PACKAGES+=(python2)
-
-#
 # revng dependencies
 #
 PACKAGES+=(doxygen)

--- a/.orchestra/config/components/python2.yml
+++ b/.orchestra/config/components/python2.yml
@@ -1,0 +1,58 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+#@ load("/lib/make.lib.yml", "make")
+#@ load("/lib/util.lib.yml", "datavalue")
+
+#@yaml/text-templated-strings
+---
+#@ def python2_component():
+#@ python_version = "2.7.18"
+#@ source_url = "https://www.python.org/ftp/python/" + python_version + "/Python-" + python_version + ".tar.xz"
+license: LICENSE
+builds:
+  default:
+    configure: |
+      mkdir -p "$BUILD_DIR"
+      extract.sh --into "$BUILD_DIR" (@= source_url @)
+
+      cd "$BUILD_DIR"
+      patch -p1 < "${ORCHESTRA_DOTDIR}/patches/python2-fixes.patch"
+
+      # orchestra's libc has a buggy getaddrinfo; we expect users to have a newer libc
+      ac_cv_buggy_getaddrinfo=no ./configure \
+        --prefix="$ORCHESTRA_ROOT" \
+        --libdir="${ORCHESTRA_ROOT}/lib64" \
+        --enable-optimizations \
+        --enable-shared \
+        --enable-ipv6 \
+        --with-lto \
+        --with-system-ffi \
+        --with-system-expat \
+        --without-ensurepip \
+        CC="gcc -ljemalloc"
+    install: |
+      cd "$BUILD_DIR"
+      (@= make @)
+      (@= make @) altinstall DESTDIR="$DESTDIR"
+
+      BINDIR="${DESTDIR}${ORCHESTRA_ROOT}/bin"
+      rm "${BINDIR}/pydoc" "${BINDIR}/idle" "${BINDIR}/2to3" "${BINDIR}/smtpd.py"
+      ln -s python2.7 "${BINDIR}/python2"
+    build_dependencies:
+      - host-c-toolchain
+    dependencies:
+      - bzip2
+      - expat
+      - libffi
+      - ncurses
+      - openssl
+      - readline
+      - sqlite
+      - host-libc
+#@ end
+
+#@overlay/match by=overlay.all, expects=1
+#@overlay/match-child-defaults missing_ok=True
+---
+components:
+  python2: #@ python2_component()

--- a/.orchestra/config/components/qemu.yml
+++ b/.orchestra/config/components/qemu.yml
@@ -35,7 +35,7 @@ builds:
           --disable-smartcard-nss \
           --disable-uuid \
           --disable-cap-ng \
-          --python="$(command -v python2)" \
+          --python="${ORCHESTRA_ROOT}/bin/python2" \
           (@ if build_type == "Debug": @)--enable-debug (@ end @)\
           --extra-cflags="(@= cflags @)"
       install: |
@@ -43,6 +43,7 @@ builds:
         (@= make @) install
       build_dependencies:
         - host-c-toolchain
+        - python2
       dependencies:
         - zlib
         - glib

--- a/.orchestra/patches/python2-fixes.patch
+++ b/.orchestra/patches/python2-fixes.patch
@@ -1,0 +1,24 @@
+--- a/Modules/main.c
++++ b/Modules/main.c
+@@ -463,9 +463,7 @@
+         (p = Py_GETENV("PYTHONUNBUFFERED")) && *p != '\0')
+         unbuffered = 1;
+ 
+-    if (!Py_NoUserSiteDirectory &&
+-        (p = Py_GETENV("PYTHONNOUSERSITE")) && *p != '\0')
+-        Py_NoUserSiteDirectory = 1;
++    Py_NoUserSiteDirectory = 1;
+ 
+     if ((p = Py_GETENV("PYTHONWARNINGS")) && *p != '\0') {
+         char *buf, *warning;
+--- a/Makefile.pre.in
++++ b/Makefile.pre.in
+@@ -211,7 +211,7 @@
+ # The task to run while instrument when building the profile-opt target
+ # We exclude unittests with -x that take a rediculious amount of time to
+ # run in the instrumented training build or do not provide much value.
+-PROFILE_TASK=-m test.regrtest --pgo -x test_asyncore test_gdb test_multiprocessing test_subprocess
++PROFILE_TASK=-m test.regrtest --pgo -x test_asyncore test_gdb test_multiprocessing test_subprocess test_docxmlrpc test_urllib2_localnet
+ 
+ # report files for gcov / lcov coverage report
+ COVERAGE_INFO= $(abs_builddir)/coverage.info


### PR DESCRIPTION
Introduce the `python2` component to be used by the `qemu` component for building.