### PR TITLE
Update black and mypy dependencies

### DIFF
--- a/.orchestra/config/components/revng-python-dependencies.yml
+++ b/.orchestra/config/components/revng-python-dependencies.yml
@@ -14,7 +14,7 @@ dependencies:
 - llvm
 requirements: |-
   # Python language checkers/formatters
-  black>=22.12.0,<23.0
+  black>=25.1.0,<26.0
   flake8>=7.0.0,<8.0
   flake8-breakpoint>=1.1.0,<2.0
   flake8-builtins>=2.1.0,<3.0
@@ -25,7 +25,7 @@ requirements: |-
   pep8-naming>=0.13.3,<1.0
   isort>=5.11.4,<6.0
   codespell>=2.2.2,<3.0
-  mypy==1.13.0
+  mypy==1.17.0
 
   # Python types, needed for mypy to work correctly
   boto3-stubs[s3]


### PR DESCRIPTION
These changes are needed for the [revng-pypeline PR #507](https://github.com/revng/revng/pull/507#issuecomment-3149630331) as we uses syntax from [PEP 695](https://peps.python.org/pep-0695/).