### PR TITLE
Add debootstrap, rootfs, and model-db orchestra components

### DIFF
--- a/.orchestra/config/components/debootstrap.yml
+++ b/.orchestra/config/components/debootstrap.yml
@@ -1,0 +1,36 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("/lib/create-component.lib.yml", "single_build_component")
+
+#@ repository_url = "https://git.launchpad.net/ubuntu/+source/debootstrap"
+#@ tag = "import/1.0.142build1"
+
+#@yaml/text-templated-strings
+---
+#@ def debootstrap_args():
+configure: |
+  mkdir -p "$BUILD_DIR"
+  git clone \
+    --depth 1 \
+    --branch "(@= tag @)" \
+    "(@= repository_url @)" \
+    "$BUILD_DIR/debootstrap"
+
+install: |
+  cd "$BUILD_DIR/debootstrap"
+
+  mkdir -p "${DESTDIR}${ORCHESTRA_ROOT}/share/debootstrap/scripts"
+  mkdir -p "${DESTDIR}${ORCHESTRA_ROOT}/bin"
+
+  cp -a scripts/* "${DESTDIR}${ORCHESTRA_ROOT}/share/debootstrap/scripts/"
+  install -m 0644 functions "${DESTDIR}${ORCHESTRA_ROOT}/share/debootstrap/"
+
+  sed 's|@VERSION@|(@= tag @)|g' debootstrap \
+    > "${DESTDIR}${ORCHESTRA_ROOT}/bin/debootstrap"
+  chmod 0755 "${DESTDIR}${ORCHESTRA_ROOT}/bin/debootstrap"
+#@ end
+
+#@overlay/match by=overlay.all, expects=1
+#@overlay/match-child-defaults missing_ok=True
+---
+components:
+  debootstrap: #@ single_build_component(**debootstrap_args())

--- a/.orchestra/config/components/model-db.yml
+++ b/.orchestra/config/components/model-db.yml
@@ -13,12 +13,15 @@ components:
       default:
         build_dependencies:
           - revng
-          #! WIP: only depending on a single rootfs for now
+          #! WIP: only depending on a single rootfs/pdb for now
           - rootfs/ubuntu-24-04-x86-64/debug-info
+          - pdb/x86-64/debug-info
         configure: |
+          mkdir -p "$BUILD_DIR"
+
+        install: |
           log() { echo "$@" >&2; }
 
-          mkdir -p "$BUILD_DIR"
           cd "$BUILD_DIR"
 
           export REVNG_NO_FETCH_DEBUG_INFO=1
@@ -70,6 +73,27 @@ components:
             done
           done
 
+          PDB_DIR="$ORCHESTRA_ROOT/share/pdb"
+
+          if test -d "$PDB_DIR"; then
+            for PDB_ARCH_DIR in "$PDB_DIR"/*/models; do
+              if ! test -d "$PDB_ARCH_DIR"; then
+                continue
+              fi
+
+              PDB_ARCH_NAME="$(basename "$(dirname "$PDB_ARCH_DIR")")"
+
+              for MODEL_FILE in "$PDB_ARCH_DIR"/*.yml; do
+                if ! test -f "$MODEL_FILE"; then
+                  continue
+                fi
+
+                MODEL_NAME="$(basename "$MODEL_FILE" .yml)"
+                cp "$MODEL_FILE" "$BUILD_DIR/models/windows-${PDB_ARCH_NAME}_${MODEL_NAME}.yml"
+              done
+            done
+          fi
+
           rm -f db.sqlite
 
           MODEL_FILES=$(find models/ -name '*.yml' -size +0c)
@@ -85,6 +109,26 @@ components:
                   --db db.sqlite \
                   --platform "$ROOTFS_NAME" \
                   $ROOTFS_MODELS
+              fi
+            done
+
+            for PDB_ARCH_DIR in "$PDB_DIR"/*/models; do
+              if ! test -d "$PDB_ARCH_DIR"; then
+                continue
+              fi
+
+              PDB_ARCH_NAME="$(basename "$(dirname "$PDB_ARCH_DIR")")"
+              PLATFORM_NAME="windows-${PDB_ARCH_NAME}"
+              PDB_MODELS=$(find models/ -name "${PLATFORM_NAME}_*.yml" -size +0c)
+              if test -n "$PDB_MODELS"; then
+                log "Exporting PDB models for $PLATFORM_NAME to SQLite..."
+                revng \
+                  model \
+                  export \
+                  sqlite \
+                  --db db.sqlite \
+                  --platform "$PLATFORM_NAME" \
+                  $PDB_MODELS
               fi
             done
           fi
@@ -121,8 +165,6 @@ components:
             fi
           fi
 
-        install: |
-          cd "$BUILD_DIR"
           mkdir -p "${DESTDIR}${ORCHESTRA_ROOT}/share/revng"
           if test -f db.sqlite; then
             cp db.sqlite "${DESTDIR}${ORCHESTRA_ROOT}/share/revng/db.sqlite"

--- a/.orchestra/config/components/model-db.yml
+++ b/.orchestra/config/components/model-db.yml
@@ -1,0 +1,129 @@
+#@ load("@ytt:overlay", "overlay")
+
+#@yaml/text-templated-strings
+---
+
+#@overlay/match by=overlay.all, expects=1
+#@overlay/match-child-defaults missing_ok=True
+---
+components:
+  model-db:
+    skip_post_install: true
+    builds:
+      default:
+        build_dependencies:
+          - revng
+          #! WIP: only depending on a single rootfs for now
+          - rootfs/ubuntu-24-04-x86-64/debug-info
+        configure: |
+          log() { echo "$@" >&2; }
+
+          mkdir -p "$BUILD_DIR"
+          cd "$BUILD_DIR"
+
+          export REVNG_NO_FETCH_DEBUG_INFO=1
+
+          ROOTS_DIR="$ORCHESTRA_ROOT/share/roots"
+
+          rm -rf models/
+          mkdir -p models
+
+          for ROOTFS_NAME in $(ls "$ROOTS_DIR"); do
+            ROOTFS_DIR="$ROOTS_DIR/$ROOTFS_NAME"
+
+            if ! test -d "$ROOTFS_DIR"; then
+              continue
+            fi
+
+            SYMBOLS_CACHE="$ROOTFS_DIR/symbols-cache"
+
+            export XDG_CACHE_HOME="$BUILD_DIR/cache"
+            mkdir -p "$XDG_CACHE_HOME"
+
+            if test -d "$SYMBOLS_CACHE"; then
+              mkdir -p "$XDG_CACHE_HOME/revng/debug-symbols/elf"
+              cp -a "$SYMBOLS_CACHE"/* "$XDG_CACHE_HOME/revng/debug-symbols/elf/" \
+                2>/dev/null || true
+            fi
+
+            # WIP: limit to 5 ELFs per rootfs
+            ELF_COUNT=0
+            for ELF_FILE in $(find "$ROOTFS_DIR" -type f); do
+              if ! head -c 4 "$ELF_FILE" 2>/dev/null | grep -q $'\x7fELF'; then
+                continue
+              fi
+
+              ELF_COUNT=$((ELF_COUNT + 1))
+              if test "$ELF_COUNT" -gt 5; then
+                break
+              fi
+
+              RELATIVE_PATH="${ELF_FILE#$ROOTFS_DIR/}"
+              MODEL_NAME="$(echo "$RELATIVE_PATH" | tr '/' '_')"
+
+              log "Importing $ROOTFS_NAME / $RELATIVE_PATH..."
+              revng \
+                analyze \
+                import-binary \
+                -o "$BUILD_DIR/models/${ROOTFS_NAME}_${MODEL_NAME}.yml" \
+                "$ELF_FILE" || true
+            done
+          done
+
+          rm -f db.sqlite
+
+          MODEL_FILES=$(find models/ -name '*.yml' -size +0c)
+          if test -n "$MODEL_FILES"; then
+            for ROOTFS_NAME in $(ls "$ROOTS_DIR"); do
+              ROOTFS_MODELS=$(find models/ -name "${ROOTFS_NAME}_*.yml" -size +0c)
+              if test -n "$ROOTFS_MODELS"; then
+                log "Exporting models for $ROOTFS_NAME to SQLite..."
+                revng \
+                  model \
+                  export \
+                  sqlite \
+                  --db db.sqlite \
+                  --platform "$ROOTFS_NAME" \
+                  $ROOTFS_MODELS
+              fi
+            done
+          fi
+
+          # Test: round-trip a few symbols through model-import-sqlite
+          if test -f db.sqlite; then
+            TEST_SYMBOLS=$(sqlite3 db.sqlite \
+              "SELECT s.Name FROM Symbol s LIMIT 3;")
+
+            if test -n "$TEST_SYMBOLS"; then
+              FIRST_LIBRARY=$(sqlite3 db.sqlite \
+                "SELECT l.Name FROM Library l LIMIT 1;")
+              FIRST_PLATFORM=$(sqlite3 db.sqlite \
+                "SELECT p.Name FROM Platform p LIMIT 1;")
+
+              SYMBOL_ARGS=""
+              for SYMBOL_NAME in $TEST_SYMBOLS; do
+                SYMBOL_ARGS="$SYMBOL_ARGS --symbol $SYMBOL_NAME"
+              done
+
+              log "Round-trip test: $TEST_SYMBOLS"
+              revng \
+                model \
+                import \
+                sqlite \
+                --db db.sqlite \
+                --platform "$FIRST_PLATFORM" \
+                --library "$FIRST_LIBRARY" \
+                $SYMBOL_ARGS \
+                -o test-round-trip.yml
+
+              log "Round-trip test passed ($(wc -l < test-round-trip.yml) lines)"
+              rm -f test-round-trip.yml
+            fi
+          fi
+
+        install: |
+          cd "$BUILD_DIR"
+          mkdir -p "${DESTDIR}${ORCHESTRA_ROOT}/share/revng"
+          if test -f db.sqlite; then
+            cp db.sqlite "${DESTDIR}${ORCHESTRA_ROOT}/share/revng/db.sqlite"
+          fi

--- a/.orchestra/config/components/pdb.yml
+++ b/.orchestra/config/components/pdb.yml
@@ -48,11 +48,14 @@ pdb/(@= name @):
           (@= arch_rsp_flags @) \
           --output-dir "$BUILD_DIR"
 
-        log "Building PDBs..."
-        ninja -C "$BUILD_DIR" -j"$(nproc)"
-
       install: |
+        log() { echo "$@" >&2; }
+
         cd "$BUILD_DIR"
+
+        log "Building PDBs..."
+        ninja -j"$(nproc)"
+
         mkdir -p "${DESTDIR}${ORCHESTRA_ROOT}/share/pdb/(@= name @)"
         for PDB_FILE in *.pdb; do
           if test -f "$PDB_FILE"; then
@@ -61,10 +64,51 @@ pdb/(@= name @):
         done
 #@ end
 
+#@yaml/text-templated-strings
+---
+#@ def create_pdb_debug_info_component(name, target_triple=None, vc_component=None, vc_triple=None, arch_rsp_flags=None):
+pdb/(@= name @)/debug-info:
+  skip_post_install: true
+  builds:
+    default:
+      build_dependencies:
+        - revng
+        - pdb/(@= name @)
+      configure: |
+        mkdir -p "$BUILD_DIR"
+
+      install: |
+        log() { echo "$@" >&2; }
+
+        cd "$BUILD_DIR"
+
+        PDB_DIR="$ORCHESTRA_ROOT/share/pdb/(@= name @)"
+
+        rm -rf models/
+        mkdir -p models
+
+        for PDB_FILE in "$PDB_DIR"/*.pdb; do
+          if ! test -f "$PDB_FILE"; then
+            continue
+          fi
+
+          PDB_NAME="$(basename "$PDB_FILE" .pdb)"
+
+          log "Importing $PDB_NAME..."
+          #! WIP: replace with actual tool invocation
+          touch "models/${PDB_NAME}.yml"
+        done
+
+        mkdir -p "${DESTDIR}${ORCHESTRA_ROOT}/share/pdb/(@= name @)/models"
+        cp -a models/* "${DESTDIR}${ORCHESTRA_ROOT}/share/pdb/(@= name @)/models/" \
+          2>/dev/null || true
+#@ end
+
 #@overlay/match by=overlay.all, expects=1
 #@overlay/match-child-defaults missing_ok=True
 ---
 components:
   #@ for configuration in pdb_configurations():
   _: #@ template.replace(create_pdb_component(**configuration))
+  _: #@ template.replace(create_pdb_debug_info_component(**configuration))
   #@ end

--- a/.orchestra/config/components/pdb.yml
+++ b/.orchestra/config/components/pdb.yml
@@ -1,0 +1,70 @@
+#@ load("@ytt:template", "template")
+#@ load("@ytt:overlay", "overlay")
+
+#@yaml/text-templated-strings
+---
+#@ def pdb_configurations():
+- name: x86-64
+  target_triple: x86_64-pc-windows-msvc
+  vc_component: toolchain/win64-vc19/vc
+  vc_triple: x86_64-winsdk-vc19
+  arch_rsp_flags: "--arch-rsp baseSettings.x64.rsp"
+- name: i386
+  target_triple: i386-pc-windows-msvc
+  vc_component: toolchain/win32-vc19/vc
+  vc_triple: i386-winsdk-vc19
+  arch_rsp_flags: "--arch-rsp baseSettings.x86.rsp --arch-rsp baseSettings.32.rsp"
+- name: aarch64
+  target_triple: aarch64-pc-windows-msvc
+  vc_component: toolchain/win64-aarch64-vc19/vc
+  vc_triple: aarch64-winsdk-vc19
+  arch_rsp_flags: "--arch-rsp baseSettings.arm64.rsp --arch-rsp baseSettings.64.rsp"
+#@ end
+
+#@yaml/text-templated-strings
+---
+#@ def create_pdb_component(name, target_triple, vc_component, vc_triple, arch_rsp_flags):
+pdb/(@= name @):
+  skip_post_install: true
+  builds:
+    default:
+      build_dependencies:
+        - clang-release
+        - (@= vc_component @)
+        - win32metadata
+        - ninja
+      configure: |
+        log() { echo "$@" >&2; }
+
+        mkdir -p "$BUILD_DIR"
+
+        log "Generating ninja build for (@= name @)..."
+        python3 "$ORCHESTRA_DOTDIR/support/compile-to-pdb.py" \
+          --win32meta-root "$ORCHESTRA_ROOT/share/win32metadata" \
+          --clang "$ORCHESTRA_ROOT/bin/clang" \
+          --lld-link "$ORCHESTRA_ROOT/bin/lld-link" \
+          --vc19-include "$ORCHESTRA_ROOT/lib/vc/(@= vc_triple @)/VC/include" \
+          --target-triple "(@= target_triple @)" \
+          (@= arch_rsp_flags @) \
+          --output-dir "$BUILD_DIR"
+
+        log "Building PDBs..."
+        ninja -C "$BUILD_DIR" -j"$(nproc)"
+
+      install: |
+        cd "$BUILD_DIR"
+        mkdir -p "${DESTDIR}${ORCHESTRA_ROOT}/share/pdb/(@= name @)"
+        for PDB_FILE in *.pdb; do
+          if test -f "$PDB_FILE"; then
+            cp "$PDB_FILE" "${DESTDIR}${ORCHESTRA_ROOT}/share/pdb/(@= name @)/"
+          fi
+        done
+#@ end
+
+#@overlay/match by=overlay.all, expects=1
+#@overlay/match-child-defaults missing_ok=True
+---
+components:
+  #@ for configuration in pdb_configurations():
+  _: #@ template.replace(create_pdb_component(**configuration))
+  #@ end

--- a/.orchestra/config/components/rootfs.yml
+++ b/.orchestra/config/components/rootfs.yml
@@ -1,0 +1,213 @@
+#@ load("@ytt:template", "template")
+#@ load("@ytt:overlay", "overlay")
+
+#@yaml/text-templated-strings
+---
+#@ def rootfs_configurations():
+- name: ubuntu-20-04-x86-64
+  codename: focal
+  architecture: amd64
+  url: "http://archive.ubuntu.com/ubuntu/"
+  operating_system: ubuntu
+  packages: "libfuse2,libc6-dbg"
+- name: ubuntu-22-04-x86-64
+  codename: jammy
+  architecture: amd64
+  url: "http://archive.ubuntu.com/ubuntu/"
+  operating_system: ubuntu
+  packages: "libfuse2,libc6-dbg"
+- name: ubuntu-24-04-x86-64
+  codename: noble
+  architecture: amd64
+  url: "http://archive.ubuntu.com/ubuntu/"
+  operating_system: ubuntu
+  packages: "libfuse3-3,libc6-dbg"
+- name: ubuntu-24-04-i386
+  codename: noble
+  architecture: i386
+  url: "http://archive.ubuntu.com/ubuntu/"
+  operating_system: ubuntu
+  packages: "libfuse3-3,libc6-dbg"
+- name: ubuntu-24-04-arm
+  codename: noble
+  architecture: armhf
+  url: "http://ports.ubuntu.com/ubuntu-ports/"
+  operating_system: ubuntu
+  packages: "libfuse3-3,libc6-dbg"
+- name: ubuntu-24-04-aarch64
+  codename: noble
+  architecture: arm64
+  url: "http://ports.ubuntu.com/ubuntu-ports/"
+  operating_system: ubuntu
+  packages: "libfuse3-3,libc6-dbg"
+- name: ubuntu-24-04-s390x
+  codename: noble
+  architecture: s390x
+  url: "http://ports.ubuntu.com/ubuntu-ports/"
+  operating_system: ubuntu
+  packages: "libfuse3-3,libc6-dbg"
+- name: debian-bookworm-mipsel
+  codename: bookworm
+  architecture: mipsel
+  url: "https://ftp.debian.org/debian/"
+  operating_system: debian
+  packages: "libfuse2,libc6-dbg"
+- name: debian-buster-mips
+  codename: buster
+  architecture: mips
+  url: "https://archive.debian.org/debian/"
+  operating_system: debian
+  packages: "libfuse2,libc6-dbg"
+#@ end
+
+#@yaml/text-templated-strings
+---
+#@ def create_rootfs_component(name, codename, architecture, url, operating_system, packages):
+#@ if operating_system == "ubuntu":
+#@   components = "main,restricted,universe,multiverse"
+#@ elif operating_system == "debian":
+#@   components = "main,contrib,non-free"
+#@ end
+rootfs/(@= name @):
+  skip_post_install: true
+  builds:
+    default:
+      build_dependencies:
+        - debootstrap
+      configure: |
+        log() { echo "$@" >&2; }
+
+        mkdir -p "$BUILD_DIR"
+        cd "$BUILD_DIR"
+
+        rm -rf rootfs/
+
+        log "Running debootstrap for (@= name @)..."
+        DEBOOTSTRAP_DIR="$ORCHESTRA_ROOT/share/debootstrap" \
+          fakeroot \
+          "$ORCHESTRA_ROOT/bin/debootstrap" \
+          --arch="(@= architecture @)" \
+          --components="(@= components @)" \
+          --include="(@= packages @)" \
+          --download-only \
+          "(@= codename @)" \
+          rootfs/ \
+          "(@= url @)" || true
+
+        log "Extracting .deb packages..."
+        find rootfs -name "*.deb" | while read DEB_FILE; do
+          mkdir -p temp
+          cd temp
+          ar x "../$DEB_FILE"
+          cd ../rootfs
+          if test -e "../temp/data.tar"*; then
+            tar xaf "../temp/data.tar"*
+          fi
+          cd ..
+          rm -rf temp
+        done
+
+        if test "$(find rootfs/ -name 'libc.so*' | wc -l)" -lt 1; then
+          log "ERROR: debootstrap (@= name @) failed"
+          exit 1
+        fi
+
+        # Cleanup: keep only symlinks, ELF files, /etc/ld.so.conf,
+        # and files in /etc/ld.so.conf.d/
+        log "Cleaning up non-ELF files..."
+        find rootfs -not -type d | while read FILE; do
+          if test -L "$FILE"; then
+            continue
+          fi
+
+          RELATIVE_PATH="${FILE#rootfs}"
+
+          if test "$RELATIVE_PATH" = "/etc/ld.so.conf"; then
+            continue
+          fi
+
+          case "$RELATIVE_PATH" in
+            /etc/ld.so.conf.d/*) continue ;;
+          esac
+
+          if head -c 4 "$FILE" 2>/dev/null | grep -q $'\x7fELF'; then
+            continue
+          fi
+
+          rm -f "$FILE"
+        done
+
+        # Fix permissions before modifying symlinks
+        chmod -R u+rwX rootfs/
+
+        # Make all symlinks relative
+        find rootfs -type l | while read LINK; do
+          TARGET="$(readlink "$LINK")"
+          if test "${TARGET#/}" != "$TARGET"; then
+            LINK_DIR="$(dirname "$LINK")"
+            RELATIVE_TARGET="$(realpath -m --relative-to="$LINK_DIR" "rootfs$TARGET")"
+            ln -sfn "$RELATIVE_TARGET" "$LINK"
+          fi
+        done
+
+        # Drop empty directories
+        find rootfs -type d -empty -delete
+
+        log "Rootfs (@= name @) ready."
+
+      install: |
+        cd "$BUILD_DIR"
+        mkdir -p "${DESTDIR}${ORCHESTRA_ROOT}/share/roots/(@= name @)"
+        cp -a rootfs/* "${DESTDIR}${ORCHESTRA_ROOT}/share/roots/(@= name @)/"
+        chmod -R u+rwX "${DESTDIR}${ORCHESTRA_ROOT}/share/roots/(@= name @)/"
+#@ end
+
+#@ def create_debug_info_component(name, codename=None, architecture=None, url=None, operating_system=None, packages=None):
+rootfs/(@= name @)/debug-info:
+  skip_post_install: true
+  builds:
+    default:
+      build_dependencies:
+        - revng
+        - rootfs/(@= name @)
+      configure: |
+        log() { echo "$@" >&2; }
+
+        mkdir -p "$BUILD_DIR"
+        cd "$BUILD_DIR"
+
+        ROOTFS_DIR="$ORCHESTRA_ROOT/share/roots/(@= name @)"
+
+        export XDG_CACHE_HOME="$BUILD_DIR/cache"
+        mkdir -p "$XDG_CACHE_HOME"
+
+        log "Fetching debug info for (@= name @)..."
+        find "$ROOTFS_DIR" -type f | while read ELF_FILE; do
+          if head -c 4 "$ELF_FILE" 2>/dev/null | grep -q $'\x7fELF'; then
+            log "  $ELF_FILE"
+            revng model fetch-debuginfo "$ELF_FILE" || true
+          fi
+        done
+
+        log "Debug info fetching complete."
+
+      install: |
+        cd "$BUILD_DIR"
+
+        SYMBOLS_SRC="$BUILD_DIR/cache/revng/debug-symbols/elf"
+        SYMBOLS_DST="${DESTDIR}${ORCHESTRA_ROOT}/share/roots/(@= name @)/symbols-cache"
+
+        if test -d "$SYMBOLS_SRC"; then
+          mkdir -p "$SYMBOLS_DST"
+          cp -a "$SYMBOLS_SRC"/* "$SYMBOLS_DST/"
+        fi
+#@ end
+
+#@overlay/match by=overlay.all, expects=1
+#@overlay/match-child-defaults missing_ok=True
+---
+components:
+  #@ for configuration in rootfs_configurations():
+  _: #@ template.replace(create_rootfs_component(**configuration))
+  _: #@ template.replace(create_debug_info_component(**configuration))
+  #@ end

--- a/.orchestra/config/components/rootfs.yml
+++ b/.orchestra/config/components/rootfs.yml
@@ -75,9 +75,11 @@ rootfs/(@= name @):
       build_dependencies:
         - debootstrap
       configure: |
+        mkdir -p "$BUILD_DIR"
+
+      install: |
         log() { echo "$@" >&2; }
 
-        mkdir -p "$BUILD_DIR"
         cd "$BUILD_DIR"
 
         rm -rf rootfs/
@@ -155,8 +157,6 @@ rootfs/(@= name @):
 
         log "Rootfs (@= name @) ready."
 
-      install: |
-        cd "$BUILD_DIR"
         mkdir -p "${DESTDIR}${ORCHESTRA_ROOT}/share/roots/(@= name @)"
         cp -a rootfs/* "${DESTDIR}${ORCHESTRA_ROOT}/share/roots/(@= name @)/"
         chmod -R u+rwX "${DESTDIR}${ORCHESTRA_ROOT}/share/roots/(@= name @)/"
@@ -171,9 +171,11 @@ rootfs/(@= name @)/debug-info:
         - revng
         - rootfs/(@= name @)
       configure: |
+        mkdir -p "$BUILD_DIR"
+
+      install: |
         log() { echo "$@" >&2; }
 
-        mkdir -p "$BUILD_DIR"
         cd "$BUILD_DIR"
 
         ROOTFS_DIR="$ORCHESTRA_ROOT/share/roots/(@= name @)"
@@ -190,9 +192,6 @@ rootfs/(@= name @)/debug-info:
         done
 
         log "Debug info fetching complete."
-
-      install: |
-        cd "$BUILD_DIR"
 
         SYMBOLS_SRC="$BUILD_DIR/cache/revng/debug-symbols/elf"
         SYMBOLS_DST="${DESTDIR}${ORCHESTRA_ROOT}/share/roots/(@= name @)/symbols-cache"

--- a/.orchestra/config/components/win32metadata.yml
+++ b/.orchestra/config/components/win32metadata.yml
@@ -1,0 +1,29 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("/lib/create-component.lib.yml", "single_build_component")
+
+#@ commit = "236161b35f4b81e7b15e02c506c7ef5799d53fbf"
+
+#@yaml/text-templated-strings
+---
+#@ def win32metadata_args():
+configure: |
+  mkdir -p "$BUILD_DIR"
+  git init "$BUILD_DIR/win32metadata"
+  cd "$BUILD_DIR/win32metadata"
+  git fetch --depth 1 \
+    "https://github.com/microsoft/win32metadata.git" \
+    "(@= commit @)"
+  git checkout FETCH_HEAD
+
+install: |
+  cd "$BUILD_DIR"
+  mkdir -p "${DESTDIR}${ORCHESTRA_ROOT}/share/win32metadata"
+  cp -a win32metadata/generation "${DESTDIR}${ORCHESTRA_ROOT}/share/win32metadata/"
+  cp -a win32metadata/sources "${DESTDIR}${ORCHESTRA_ROOT}/share/win32metadata/"
+#@ end
+
+#@overlay/match by=overlay.all, expects=1
+#@overlay/match-child-defaults missing_ok=True
+---
+components:
+  win32metadata: #@ single_build_component(**win32metadata_args())

--- a/.orchestra/config/components/win32metadata.yml
+++ b/.orchestra/config/components/win32metadata.yml
@@ -1,7 +1,7 @@
 #@ load("@ytt:overlay", "overlay")
 #@ load("/lib/create-component.lib.yml", "single_build_component")
 
-#@ commit = "236161b35f4b81e7b15e02c506c7ef5799d53fbf"
+#@ commit = "223f4b9723d8fb7c83c286b6b4ad75dff18985c4"
 
 #@yaml/text-templated-strings
 ---

--- a/.orchestra/support/compile-to-pdb.py
+++ b/.orchestra/support/compile-to-pdb.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""
+Generate a build.ninja to compile win32metadata partitions into PDBs.
+
+Usage:
+    python3 compile-to-pdb.py [options] [PARTITION ...]   # generate build.ninja
+    ninja -C build                                         # build all PDBs
+    ninja -C build Memory.pdb                              # build one PDB
+    ninja -C build -j$(nproc)                              # parallel build
+
+Compiler flags are read from the win32metadata .rsp files
+(sources/GeneratorSdk/tools/assets/scraper/baseSettings*.rsp).
+"""
+
+import argparse
+import os
+import sys
+
+
+def log(message: str) -> None:
+    print(message, file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# .rsp parsing
+# ---------------------------------------------------------------------------
+
+def parse_rsp_additional_flags(rsp_path):
+    """Extract clang flags from --additional sections of a ClangSharp .rsp file."""
+    flags = []
+    in_additional = False
+    with open(rsp_path) as f:
+        for line in f:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if stripped == "--additional":
+                in_additional = True
+                continue
+            if stripped.startswith("--"):
+                in_additional = False
+                continue
+            if in_additional:
+                flags.append(stripped)
+    return flags
+
+
+def parse_rsp_traverse_files(rsp_path, include_root, partition_dir):
+    """Extract --traverse file paths from a ClangSharp .rsp file.
+
+    Resolves <IncludeRoot> and <PartitionDir> placeholders to absolute paths.
+    """
+    paths = []
+    in_traverse = False
+    with open(rsp_path) as f:
+        for line in f:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if stripped == "--traverse":
+                in_traverse = True
+                continue
+            if stripped.startswith("--"):
+                in_traverse = False
+                continue
+            if in_traverse:
+                resolved = stripped.replace("<IncludeRoot>", include_root)
+                resolved = resolved.replace("<PartitionDir>", partition_dir)
+                paths.append(resolved)
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# Partition discovery
+# ---------------------------------------------------------------------------
+
+def discover_partitions(partitions_dir):
+    """Return sorted list of partition names that have a main.cpp."""
+    names = []
+    for entry in sorted(os.listdir(partitions_dir)):
+        if os.path.isfile(os.path.join(partitions_dir, entry, "main.cpp")):
+            names.append(entry)
+    return names
+
+
+# ---------------------------------------------------------------------------
+# Ninja generation helpers
+# ---------------------------------------------------------------------------
+
+def ninja_escape(s):
+    """Escape a string for ninja build file syntax."""
+    return s.replace("$", "$$").replace(" ", "$ ").replace(":", "$:")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate build.ninja for win32metadata PDB compilation.",
+    )
+    parser.add_argument(
+        "partitions", nargs="*",
+        help="Partition names to include (default: all)",
+    )
+    parser.add_argument(
+        "--win32meta-root",
+        default=os.path.expanduser("~/win32metadata"),
+        help="Path to win32metadata repo root (default: ~/win32metadata)",
+    )
+    parser.add_argument(
+        "--output-dir", "-o", default="build",
+        help="Output directory for build.ninja and PDBs (default: build)",
+    )
+    parser.add_argument(
+        "--clang",
+        default=os.path.expanduser("~/llvm-project/build/bin/clang"),
+        help="Path to patched clang binary",
+    )
+    parser.add_argument(
+        "--lld-link", default="lld-link",
+        help="lld-link command (default: lld-link)",
+    )
+    parser.add_argument(
+        "--vc19-include",
+        default=os.path.expanduser("~/pdb-test/vc19-include/include"),
+        help="Path to VC19 CRT include directory",
+    )
+    parser.add_argument(
+        "--target-triple",
+        default="x86_64-pc-windows-msvc",
+        help="Clang target triple (default: x86_64-pc-windows-msvc)",
+    )
+    parser.add_argument(
+        "--arch-rsp", action="append", default=[],
+        help="Architecture-specific .rsp file name (repeatable, "
+             "default: baseSettings.x64.rsp)",
+    )
+    args = parser.parse_args()
+
+    # --- Derive paths from win32metadata root --------------------------------
+    root = os.path.abspath(args.win32meta_root)
+    partitions_dir = os.path.join(root, "generation", "WinSDK", "Partitions")
+    sdk_inc_root = os.path.join(root, "generation", "WinSDK", "RecompiledIdlHeaders")
+    additional_inc = os.path.join(root, "generation", "WinSDK", "inc")
+    scraper_dir = os.path.join(
+        root, "sources", "GeneratorSdk", "tools", "assets", "scraper",
+    )
+    base_rsp = os.path.join(scraper_dir, "baseSettings.rsp")
+
+    arch_rsp_names = args.arch_rsp if args.arch_rsp else ["baseSettings.x64.rsp"]
+    arch_rsp_paths = [os.path.join(scraper_dir, name) for name in arch_rsp_names]
+
+    for path, label in [
+        (partitions_dir, "Partitions directory"),
+        (base_rsp, "baseSettings.rsp"),
+    ] + [(p, os.path.basename(p)) for p in arch_rsp_paths]:
+        if not os.path.exists(path):
+            print(f"error: {label} not found: {path}", file=sys.stderr)
+            sys.exit(1)
+
+    # --- Parse compiler flags from .rsp files --------------------------------
+    clang_flags = parse_rsp_additional_flags(base_rsp)
+    for arch_rsp_path in arch_rsp_paths:
+        clang_flags += parse_rsp_additional_flags(arch_rsp_path)
+
+    include_dirs = [
+        additional_inc,
+        os.path.abspath(args.vc19_include),
+        os.path.join(sdk_inc_root, "shared"),
+        os.path.join(sdk_inc_root, "um"),
+        os.path.join(sdk_inc_root, "ucrt"),
+        os.path.join(sdk_inc_root, "winrt"),
+    ]
+    # Also add any subdirectories (cpdk, gl, alljoyn_c, etc.)
+    for root_sub in include_dirs[-4:]:
+        for entry in sorted(os.listdir(root_sub)):
+            sub = os.path.join(root_sub, entry)
+            if os.path.isdir(sub):
+                include_dirs.append(sub)
+
+    # --- Discover / validate partitions --------------------------------------
+    all_partitions = discover_partitions(partitions_dir)
+    if args.partitions:
+        unknown = set(args.partitions) - set(all_partitions)
+        if unknown:
+            print(
+                f"error: unknown partition(s): {', '.join(sorted(unknown))}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        partitions = args.partitions
+    else:
+        partitions = all_partitions
+
+    # --- Prepare output directories ------------------------------------------
+    output_dir = os.path.abspath(args.output_dir)
+    obj_dir = os.path.join(output_dir, "obj")
+    os.makedirs(obj_dir, exist_ok=True)
+
+    clang_bin = os.path.abspath(args.clang)
+    lld_link = args.lld_link
+
+    # --- Write shared clang response file ------------------------------------
+    # Using a response file (@file) avoids shell-escaping issues with flags
+    # like -Wno-#pragma-messages.
+    rsp_file = os.path.join(obj_dir, "_compile.rsp")
+    with open(rsp_file, "w") as f:
+        f.write(f"--target={args.target_triple}\n")
+        f.write("-gcodeview\n")
+        f.write("-g\n")
+        f.write("-fno-eliminate-unused-debug-types\n")
+        f.write("-c\n")
+        for d in include_dirs:
+            f.write(f"-I{d}\n")
+        for flag in clang_flags:
+            f.write(f"{flag}\n")
+        # Suppress remaining warnings — we only care about debug info.
+        f.write("-w\n")
+
+    # --- Generate build.ninja ------------------------------------------------
+    ninja_path = os.path.join(output_dir, "build.ninja")
+
+    rsp_e = ninja_escape(rsp_file)
+
+    with open(ninja_path, "w") as nf:
+        w = nf.write
+
+        w(f"# Generated by compile-to-pdb.py — {len(partitions)} partitions\n\n")
+
+        # Variables (avoid "rspfile" — it's reserved by ninja)
+        w(f"clang = {ninja_escape(clang_bin)}\n")
+        w(f"lld_link = {ninja_escape(lld_link)}\n")
+        w(f"compile_rsp = {rsp_e}\n\n")
+
+        # Rules
+        w("rule cc\n")
+        w("  command = PDB_TRAVERSE_FILE=$traverse_file $clang @$compile_rsp -o $out $in\n")
+        w("  description = CC $partition\n\n")
+
+        # Link .obj into a dummy DLL just to produce the PDB.
+        # -dll -noentry       → no entry point needed
+        # -nodefaultlib       → no import libraries needed
+        # -force:unresolved   → ignore missing symbols (e.g. GUID_NULL)
+        w("rule link\n")
+        w("  command = $lld_link -dll -noentry -nodefaultlib -force:unresolved"
+          " -debug -pdb:$pdb -out:$out $in 2>&1 | grep -v -e '^lld-link' -e '^>>>' || true\n")
+        w("  description = PDB $partition\n\n")
+
+        # Per-partition targets
+        pdb_aliases = []
+        for name in partitions:
+            cpp = os.path.join(partitions_dir, name, "main.cpp")
+            obj = os.path.join(obj_dir, f"{name}.obj")
+            dll = os.path.join(obj_dir, f"{name}.dll")
+            pdb = os.path.join(output_dir, f"{name}.pdb")
+            traverse_file = os.path.join(obj_dir, f"{name}.traverse")
+
+            # Write per-partition traverse whitelist
+            settings_rsp = os.path.join(partitions_dir, name, "settings.rsp")
+            partition_dir = os.path.join(partitions_dir, name)
+            traverse_paths = parse_rsp_traverse_files(
+                settings_rsp, sdk_inc_root, partition_dir,
+            )
+            with open(traverse_file, "w") as tf:
+                for p in traverse_paths:
+                    tf.write(p + "\n")
+
+            cpp_e = ninja_escape(cpp)
+            obj_e = ninja_escape(obj)
+            dll_e = ninja_escape(dll)
+            pdb_e = ninja_escape(pdb)
+            traverse_e = ninja_escape(traverse_file)
+
+            # compile main.cpp -> .obj
+            w(f"build {obj_e}: cc {cpp_e}\n")
+            w(f"  partition = {name}\n")
+            w(f"  traverse_file = {traverse_e}\n")
+
+            # link .obj -> dummy .dll (+ .pdb as implicit output)
+            w(f"build {dll_e} | {pdb_e}: link {obj_e}\n")
+            w(f"  pdb = {pdb_e}\n")
+            w(f"  partition = {name}\n")
+
+            # phony alias: `ninja Memory.pdb`
+            w(f"build {name}.pdb: phony {pdb_e}\n\n")
+            pdb_aliases.append(f"{name}.pdb")
+
+        # Default target
+        w(f"build all: phony {' '.join(pdb_aliases)}\n")
+        w("default all\n")
+
+    log(f"wrote {ninja_path}  ({len(partitions)} partitions)")
+    log(f"  rsp: {rsp_file}")
+    log(f"  flags from: {base_rsp}")
+    for arch_rsp_path in arch_rsp_paths:
+        log(f"             {arch_rsp_path}")
+    log(f"\nrun:  ninja -C {output_dir}")
+    log(f"      ninja -C {output_dir} Memory.pdb        # single partition")
+    log(f"      ninja -C {output_dir} -j$(nproc)        # parallel")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `debootstrap` component that builds the debootstrap tool from source
- Add 9 `rootfs/*` components that create minimal Linux rootfs images using debootstrap across multiple architectures (Ubuntu 20.04/22.04/24.04 x86-64, Ubuntu 24.04 i386/arm/aarch64/s390x, Debian bookworm mipsel, Debian buster mips), with companion `debug-info` components that pre-fetch debug symbols
- Add `model-db` component that runs `revng analyze import-binary` on rootfs ELFs and exports the resulting models into a shared SQLite database using `revng model export sqlite`
- Add `win32metadata` component that downloads the microsoft/win32metadata source
- Add `pdb/x86-64`, `pdb/i386`, and `pdb/aarch64` components that compile all win32metadata partitions into PDB files using clang with CodeView debug info

Depends on: revng/revng#559 for `revng model export sqlite`, `revng model import sqlite`, and `REVNG_NO_FETCH_DEBUG_INFO`.

## Test plan

- [ ] `orc install debootstrap` succeeds
- [ ] `orc install rootfs/ubuntu-24-04-x86-64` produces a rootfs with ELF binaries
- [ ] `orc install rootfs/ubuntu-24-04-x86-64/debug-info` fetches debug symbols
- [ ] `orc install -b model-db` builds the SQLite database and passes the round-trip test
- [ ] `orc install win32metadata` downloads and installs the source tree
- [ ] `orc install pdb/x86-64` builds PDB files for all partitions
- [ ] `orc install pdb/i386` builds PDB files for all partitions
- [ ] `orc install pdb/aarch64` builds PDB files for all partitions